### PR TITLE
Fix myriad configuration filename not correct in the doc myriad-dev.md

### DIFF
--- a/docs/myriad-dev.md
+++ b/docs/myriad-dev.md
@@ -105,7 +105,7 @@ Optional: If you would like to enable cgroups, please add following to ```yarn-s
 </property>
 ```
 
-And, following to ```$YARN_HOME/etc/hadoop/myriad-default-config.yml```:
+And, following to ```$YARN_HOME/etc/hadoop/myriad-config-default.yml```:
 
 ```yaml
 ...


### PR DESCRIPTION
In Main.java, configuration filename is `myriad-config-default.yml`
That mismatch makes somebody(like me) confused without any error messages printed.
