### PR TITLE
fixed 404 issue with vagrants new url naming format

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.box_url = "https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box"
+  config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64"
 
   # Forward mesos master and slave ports
   config.vm.network "forwarded_port", guest: 5005, host: 5005


### PR DESCRIPTION
The box_url format changed in the latest vagrant.  This PR fixes an otherwise broken vagrant build.
