### PR TITLE
setting up static ip address

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.box_url = "https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box"
 
+  # Consistent IP for demos and tutorials (10.141.141.10 is mesosphere playa address)
+  config.vm.network :private_network, ip: "10.141.141.20"
+
   # Forward mesos master and slave ports
   config.vm.network "forwarded_port", guest: 5005, host: 5005
   config.vm.network "forwarded_port", guest: 5050, host: 5050

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -76,7 +76,7 @@ To configure YARN to use Myriad, please update ```$YARN_HOME/etc/hadoop/yarn-sit
 
 To configure Myriad itself, please add following file to ```$YARN_HOME/etc/hadoop/myriad-default-config.yml```:
 ```yml
-mesosMaster: 10.0.2.15:5050
+mesosMaster: 10.141.141.20:5050
 checkpoint: false
 frameworkFailoverTimeout: 43200000
 frameworkName: MyriadAlpha


### PR DESCRIPTION
It is convenient for demos and tutorials to have a static IP.  The [Playa project](https://github.com/mesosphere/playa-mesos) uses 10.141.141.10.  It made sense to use something similar.   This is setup as 10.141.141.20.
