### PR TITLE
fixed 404 for invalid hadoop version

### DIFF
--- a/setup-yarn-2.sh
+++ b/setup-yarn-2.sh
@@ -1,6 +1,6 @@
 set -e
 
-HADOOP_VER=2.5.0
+HADOOP_VER=2.5.2
 
 # Download Hadoop
 cd ~


### PR DESCRIPTION
hadoop 2.5.0 is not valid any more.  the closest alternative is 2.5.2
