### PR TITLE
gradlew is the safest way to build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,6 @@ apt-get -y install oracle-java8-set-default
 apt-get -y install libcurl3
 apt-get -y install zookeeperd
 apt-get -y install aria2
-apt-get -y install gradle 
 
 MESOS_VERSION="0.20.0"
 echo "${PREFIX}Downloading mesos version: ${MESOS_VERSION} for ubuntu: 14.04"

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -42,7 +42,7 @@ If everything goes fine you'll see following processes running (process ids will
 To build myriad scheduler inside VM, you can do following:
 ```shell
 cd /vagrant
-gradle build
+./gradlew build
 ```
 
 At this point, myriad's scheduler jar and all the runtime dependencies will be available here: /vagrant/build/libs/*. Please copy these jars to $YARN_HOME/share/hadoop/yarn/lib/.
@@ -50,7 +50,7 @@ At this point, myriad's scheduler jar and all the runtime dependencies will be a
 To build self-contained executable JAR, you can run following:
 ```shell
 cd /vagrant
-gradle capsuleExecutor
+./gradlew capsuleExecutor
 ```
 
 At this point, the self-contained myriad executor jar will be available here: /vagrant/build/libs/myriad-executor-x.y.z.jar. Please copy this jar to /usr/local/libexec/mesos/.


### PR DESCRIPTION
gradle installed to the vm does NOT work.  It naively `export JAVA_HOME=/usr/lib/jvm/default-java` which isn't true for this installation.  Fixes could include removing that line, because JAVA_HOME is already good or putting in a symlink.   However gradlew is the best way IMO.  the installation of gradle could be any future version which could eventually break this build.   Using gradlew pulls the right version for the build every time.
