### PR TITLE
Working prototype of fine grained scaling

### DIFF
--- a/src/main/java/com/ebay/myriad/executor/ContainerTaskStatusRequest.java
+++ b/src/main/java/com/ebay/myriad/executor/ContainerTaskStatusRequest.java
@@ -1,0 +1,25 @@
+package com.ebay.myriad.executor;
+
+import org.apache.mesos.Protos;
+
+public class ContainerTaskStatusRequest {
+    public static final String YARN_CONTAINER_TASK_ID_PREFIX = "yarn_";
+    private String mesosTaskId; // YARN_CONTAINER_TASK_ID_PREFIX + <container_id>
+    private String state; // Protos.TaskState.name()
+
+    public String getMesosTaskId() {
+        return mesosTaskId;
+    }
+
+    public void setMesosTaskId(String mesosTaskId) {
+        this.mesosTaskId = mesosTaskId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/ebay/myriad/policy/LeastAMNodesFirstPolicy.java
+++ b/src/main/java/com/ebay/myriad/policy/LeastAMNodesFirstPolicy.java
@@ -80,7 +80,7 @@ public class LeastAMNodesFirstPolicy extends BaseInterceptor implements NodeScal
     }
 
     @Override
-    public void onEventHandled(SchedulerEvent event) {
+    public void afterSchedulerEventHandled(SchedulerEvent event) {
         switch (event.getType()) {
             case NODE_UPDATE:
                 onNodeUpdated((NodeUpdateSchedulerEvent) event);

--- a/src/main/java/com/ebay/myriad/scheduler/MyriadDriver.java
+++ b/src/main/java/com/ebay/myriad/scheduler/MyriadDriver.java
@@ -80,4 +80,8 @@ public class MyriadDriver {
         LOGGER.info("Driver aborted with status: {}", status);
         return status;
     }
+
+    public MesosSchedulerDriver getDriver() {
+        return driver;
+    }
 }

--- a/src/main/java/com/ebay/myriad/scheduler/TaskFactory.java
+++ b/src/main/java/com/ebay/myriad/scheduler/TaskFactory.java
@@ -21,6 +21,13 @@ import java.util.Objects;
 public interface TaskFactory {
     TaskInfo createTask(Offer offer, TaskID taskId, NodeTask nodeTask);
 
+    // TODO(Santosh): This is needed because the ExecutorInfo constructed
+    // to launch NM needs to be specified to launch placeholder tasks for
+    // yarn containers (for fine grained scaling).
+    // If mesos supports just specifying the 'ExecutorId' without the full
+    // ExecutorInfo, we wouldn't need this interface method.
+    ExecutorInfo getExecutorInfoForSlave(SlaveID slave);
+
     class NMTaskFactoryImpl implements TaskFactory {
         public static final String EXECUTOR_NAME = "myriad_task";
         public static final String EXECUTOR_PREFIX = "myriad_executor";
@@ -92,37 +99,7 @@ public interface TaskFactory {
                     .setValue(taskUtils.getTaskMemory(profile)).build();
             Scalar taskCpus = Value.Scalar.newBuilder()
                     .setValue(taskUtils.getTaskCpus(profile)).build();
-            Scalar executorMemory = Value.Scalar.newBuilder()
-                    .setValue(taskUtils.getExecutorMemory()).build();
-            Scalar executorCpus = Value.Scalar.newBuilder()
-                    .setValue(taskUtils.getExecutorCpus()).build();
-
-            String executorPath = cfg.getMyriadExecutorConfiguration()
-                    .getPath();
-            URI executorURI = URI.newBuilder().setValue(executorPath)
-                    .setExecutable(true).build();
-
-            CommandInfo commandInfo = CommandInfo.newBuilder()
-                    .addUris(executorURI).setUser("root")
-                    .setValue("export CAPSULE_CACHE_DIR=`pwd`;echo $CAPSULE_CACHE_DIR; java -Dcapsule.log=verbose -jar " + getFileName(executorPath))
-                    .build();
-
-            ExecutorID executorId = Protos.ExecutorID.newBuilder()
-                    .setValue(EXECUTOR_PREFIX + offer.getSlaveId().getValue())
-                    .build();
-            ExecutorInfo executorInfo = ExecutorInfo
-                    .newBuilder()
-                    .setCommand(commandInfo)
-                    .setName(EXECUTOR_NAME)
-                    .addResources(
-                            Resource.newBuilder().setName("cpus")
-                                    .setType(Value.Type.SCALAR)
-                                    .setScalar(executorCpus).build())
-                    .addResources(
-                            Resource.newBuilder().setName("mem")
-                                    .setType(Value.Type.SCALAR)
-                                    .setScalar(executorMemory).build())
-                    .setExecutorId(executorId).setCommand(commandInfo).build();
+            ExecutorInfo executorInfo = getExecutorInfoForSlave(offer.getSlaveId());
 
             TaskInfo.Builder taskBuilder = TaskInfo.newBuilder()
                     .setName("task-" + taskId.getValue()).setTaskId(taskId)
@@ -140,6 +117,41 @@ public interface TaskFactory {
                                     .setType(Value.Type.SCALAR)
                                     .setScalar(taskMemory).build())
                     .setExecutor(executorInfo).setData(data).build();
+        }
+
+        @Override
+        public ExecutorInfo getExecutorInfoForSlave(SlaveID slave) {
+            Scalar executorMemory = Scalar.newBuilder()
+                    .setValue(taskUtils.getExecutorMemory()).build();
+            Scalar executorCpus = Scalar.newBuilder()
+                    .setValue(taskUtils.getExecutorCpus()).build();
+
+            String executorPath = cfg.getMyriadExecutorConfiguration()
+                    .getPath();
+            URI executorURI = URI.newBuilder().setValue(executorPath)
+                    .setExecutable(true).build();
+
+            CommandInfo commandInfo = CommandInfo.newBuilder()
+                    .addUris(executorURI).setUser("root")
+                    .setValue("export CAPSULE_CACHE_DIR=`pwd`;echo $CAPSULE_CACHE_DIR; java -Dcapsule.log=verbose -jar " + getFileName(executorPath))
+                    .build();
+
+            ExecutorID executorId = ExecutorID.newBuilder()
+                .setValue(EXECUTOR_PREFIX + slave.getValue())
+                    .build();
+            return ExecutorInfo
+                    .newBuilder()
+                    .setCommand(commandInfo)
+                    .setName(EXECUTOR_NAME)
+                    .addResources(
+                            Resource.newBuilder().setName("cpus")
+                                    .setType(Value.Type.SCALAR)
+                                    .setScalar(executorCpus).build())
+                    .addResources(
+                            Resource.newBuilder().setName("mem")
+                                    .setType(Value.Type.SCALAR)
+                                    .setScalar(executorMemory).build())
+                .setExecutorId(executorId).build();
         }
     }
 }

--- a/src/main/java/com/ebay/myriad/scheduler/YarnNodeCapacityManager.java
+++ b/src/main/java/com/ebay/myriad/scheduler/YarnNodeCapacityManager.java
@@ -1,0 +1,247 @@
+package com.ebay.myriad.scheduler;
+
+import com.ebay.myriad.executor.ContainerTaskStatusRequest;
+import com.ebay.myriad.scheduler.yarn.interceptor.BaseInterceptor;
+import com.ebay.myriad.scheduler.yarn.interceptor.InterceptorRegistry;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import org.apache.hadoop.yarn.api.records.*;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeStatusEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeAddedSchedulerEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeUpdateSchedulerEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEvent;
+import org.apache.hadoop.yarn.util.resource.Resources;
+import org.apache.mesos.Protos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class YarnNodeCapacityManager extends BaseInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnNodeCapacityManager.class);
+    private final AbstractYarnScheduler yarnScheduler;
+    private final MyriadDriver myriadDriver;
+
+    // TODO(Santosh): Define a single class that encapsulates (Offer, SchedulerNode, containersBeforeHB)
+    private Map<String, Protos.Offer> offersMap = new ConcurrentHashMap<>(200, 0.75f, 50);
+    private Map<String, SchedulerNode> schedulerNodes = new ConcurrentHashMap<>(200, 0.75f, 50);
+    private Map<NodeId, Set<RMContainer>> containersBeforeHB = new ConcurrentHashMap<>(200, 0.75f, 50);
+    private Map<String, Protos.SlaveID> slaves = new ConcurrentHashMap<>(200, 0.75f, 50);
+
+    @Inject
+    public YarnNodeCapacityManager(InterceptorRegistry registry, AbstractYarnScheduler yarnScheduler, MyriadDriver myriadDriver) {
+        if (registry != null) {
+            registry.register(this);
+        }
+        this.yarnScheduler = yarnScheduler;
+        this.myriadDriver = myriadDriver;
+    }
+
+    public void addResourceOffers(List<Protos.Offer> offers) {
+        for (Protos.Offer offer : offers) {
+            if (schedulerNodes.containsKey(offer.getHostname())) {
+                offersMap.put(offer.getHostname(), offer);
+                slaves.put(offer.getHostname(), offer.getSlaveId());
+            } else {
+                myriadDriver.getDriver().declineOffer(offer.getId());
+            }
+        }
+    }
+
+    @Override
+    public void beforeRMNodeEventHandled(RMNodeEvent event, RMContext context) {
+        switch (event.getType()) {
+            case STARTED: {
+                // TODO(Santosh): We can't zero out resources here in all cases. For e.g.
+                // this event might be fired when an existing node is rejoining the
+                // cluster (NM restart) as well. Sometimes this event can have a list of
+                // container statuses, which, capacity/fifo schedulers seem to handle
+                // (perhaps due to work preserving NM restart).
+                RMNode addedRMNode = context.getRMNodes().get(event.getNodeId());
+                addedRMNode.setResourceOption(
+                    ResourceOption.newInstance(Resource.newInstance(0, 0),
+                        RMNode.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT));
+            }
+            break;
+
+            case EXPIRE: {
+                schedulerNodes.remove(event.getNodeId().getHost());
+            }
+            break;
+
+            case STATUS_UPDATE: {
+                RMNodeStatusEvent statusEvent = (RMNodeStatusEvent) event;
+                RMNode rmNode = context.getRMNodes().get(event.getNodeId());
+                SchedulerNode schedulerNode = yarnScheduler.getSchedulerNode(rmNode.getNodeID());
+                String hostName = rmNode.getNodeID().getHost();
+                Protos.Offer offer = offersMap.get(hostName);
+
+                int rmSchNodeNumContainers = schedulerNode.getNumContainers();
+
+                List<ContainerStatus> nmContainers = statusEvent.getContainers();
+
+                if (nmContainers.size() != rmSchNodeNumContainers) {
+                    LOGGER.warn("Node: {}, Num Containers known by RM scheduler: {}, Num containers NM is reporting: {}",
+                        hostName, rmSchNodeNumContainers, nmContainers.size());
+                }
+
+                Resource nmFreed = Resource.newInstance(0, 0);
+                Resource nmUnderUse = Resource.newInstance(0, 0);
+                for (ContainerStatus status : nmContainers) {
+                    ContainerId containerId = status.getContainerId();
+                    Resource allocatedResource = yarnScheduler.getRMContainer(containerId).getAllocatedResource();
+                    if (status.getState() == ContainerState.COMPLETE) {
+                        Resources.addTo(nmFreed, allocatedResource);
+                        requestExecutorToSendTaskStatusUpdate(slaves.get(hostName),
+                            containerId, Protos.TaskState.TASK_FINISHED);
+                    } else { // state == NEW | RUNNING
+                        Resources.addTo(nmUnderUse, allocatedResource);
+                        requestExecutorToSendTaskStatusUpdate(slaves.get(hostName),
+                            containerId, Protos.TaskState.TASK_RUNNING);
+                    }
+                }
+
+                Resource mesosOffer = getResourceFromOffer(offer);
+                // capacity of NM at this moment = (mesos offer) + (nmUnderUse) - (nmFreed)
+                // this may take the capacity to negative if mesos offer is zero. it is ok
+                // because when we set this 'new node capacity' into RMNode, the scheduler first
+                // picks the negative value, then adds the 'nmFreed' resources to the node capacity.
+                // So, finally after processing this HB, the capacity of the node as known by the scheduler
+                // will be equal to 'nmUnderUse'.
+                Resource nmNewCapacity = Resources.subtract(Resources.add(nmUnderUse, mesosOffer), nmFreed);
+                rmNode.setResourceOption(ResourceOption.newInstance(
+                    nmNewCapacity, RMNode.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT));
+                containersBeforeHB.put(rmNode.getNodeID(), new HashSet<>(
+                    schedulerNode.getRunningContainers()));
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("(Before HB Handled) Node: {}, NM Freed: {}, Under NM's use: {}, " +
+                            "Mesos Offer: {}, New NM Capacity: {}", hostName, nmFreed.toString(),
+                        nmUnderUse.toString(), mesosOffer.toString(), nmNewCapacity.toString());
+                }
+            }
+            break;
+        }
+    }
+
+    @Override
+    public void afterSchedulerEventHandled(SchedulerEvent event) {
+        switch (event.getType()) {
+            case NODE_ADDED: {
+                NodeAddedSchedulerEvent nodeAddedEvent = (NodeAddedSchedulerEvent)event;
+                String host = nodeAddedEvent.getAddedRMNode().getNodeID().getHost();
+                if (schedulerNodes.containsKey(host)) {
+                    LOGGER.warn("Duplicate node being added. Host: {}", host);
+                }
+                schedulerNodes.put(host, yarnScheduler.getSchedulerNode(nodeAddedEvent.getAddedRMNode().getNodeID()));
+            }
+            break;
+
+            case NODE_UPDATE: {
+                RMNode rmNode = ((NodeUpdateSchedulerEvent) event).getRMNode();
+                String host = rmNode.getNodeID().getHost();
+
+                Set<RMContainer> containersBeforeHB = this.containersBeforeHB.get(rmNode.getNodeID());
+                Set<RMContainer> containersAfterHB = new HashSet<>(yarnScheduler.getSchedulerNode(
+                    rmNode.getNodeID()).getRunningContainers());
+                Set<RMContainer> containersAllocatedDueToMesosOffer =
+                    Sets.difference(containersAfterHB, containersBeforeHB).immutableCopy();
+
+                Protos.Offer offer = offersMap.get(host);
+                if (containersAllocatedDueToMesosOffer.isEmpty()) {
+                    if (offer != null) {
+                        myriadDriver.getDriver().declineOffer(offer.getId());
+                    }
+                } else {
+                    List<Protos.TaskInfo> tasks = Lists.newArrayList();
+                    for (RMContainer newContainer : containersAllocatedDueToMesosOffer) {
+                        tasks.add(getTaskInfoForContainer(newContainer, offer.getSlaveId()));
+                    }
+                    myriadDriver.getDriver().launchTasks(offer.getId(), tasks);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Launched containers: {} for offer: {}",
+                            containersAllocatedDueToMesosOffer.toString(),
+                            offersMap.get(host).getId().getValue());
+                    }
+                    offersMap.remove(host);
+                }
+            }
+            break;
+        }
+    }
+
+    /** sends a request to executor on the given slave to send back a status update
+     * for the task launched for this container.
+     *
+     * TODO(Santosh): An aux-service on the NM might be a better way to do this.
+     *
+     * @param slaveId
+     * @param containerId
+     * @param taskState
+     */
+    private void requestExecutorToSendTaskStatusUpdate(Protos.SlaveID slaveId,
+                                                       ContainerId containerId,
+                                                       Protos.TaskState taskState) {
+        ContainerTaskStatusRequest containerTaskStatusRequest = new ContainerTaskStatusRequest();
+        containerTaskStatusRequest.setMesosTaskId(
+            ContainerTaskStatusRequest.YARN_CONTAINER_TASK_ID_PREFIX + containerId.toString());
+        containerTaskStatusRequest.setState(taskState.name());
+        myriadDriver.getDriver().sendFrameworkMessage(
+            getExecutorId(slaveId),
+            slaveId,
+            new Gson().toJson(containerTaskStatusRequest).getBytes());
+    }
+
+    private Protos.ExecutorID getExecutorId(Protos.SlaveID slaveId) {
+        return Protos.ExecutorID.newBuilder().setValue(
+            TaskFactory.NMTaskFactoryImpl.EXECUTOR_PREFIX + slaveId.getValue()).build();
+    }
+
+    private Resource getResourceFromOffer(Protos.Offer offer) {
+        int cpus = 0;
+        int mem = 0;
+        if (offer != null) {
+            for (Protos.Resource resource : offer.getResourcesList()) {
+                if (resource.getName().equalsIgnoreCase("cpus")) {
+                    cpus += Math.round(resource.getScalar().getValue());
+                } else if (resource.getName().equalsIgnoreCase("mem")) {
+                    mem += Math.round(resource.getScalar().getValue());
+                }
+            }
+        }
+        return Resource.newInstance(mem, cpus);
+    }
+
+    private Protos.TaskInfo getTaskInfoForContainer(RMContainer rmContainer, Protos.SlaveID slaveId) {
+        Container container = rmContainer.getContainer();
+        Protos.TaskID taskId = Protos.TaskID.newBuilder()
+            .setValue(ContainerTaskStatusRequest.YARN_CONTAINER_TASK_ID_PREFIX + container.getId().toString()).build();
+
+        return Protos.TaskInfo.newBuilder()
+            .setName("task " + taskId.getValue())
+            .setTaskId(taskId)
+            .setSlaveId(slaveId)
+            .addResources(Protos.Resource.newBuilder()
+                .setName("cpus")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(container.getResource().getVirtualCores())))
+            .addResources(Protos.Resource.newBuilder()
+                .setName("mem")
+                .setType(Protos.Value.Type.SCALAR)
+                .setScalar(Protos.Value.Scalar.newBuilder().setValue(container.getResource().getMemory())))
+//            .setExecutor(Protos.ExecutorInfo.newBuilder(nmExecutorInfo))
+            .build();
+    }
+}

--- a/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -15,10 +15,7 @@
  */
 package com.ebay.myriad.scheduler.event.handlers;
 
-import com.ebay.myriad.scheduler.NMProfile;
-import com.ebay.myriad.scheduler.SchedulerUtils;
-import com.ebay.myriad.scheduler.TaskFactory;
-import com.ebay.myriad.scheduler.TaskUtils;
+import com.ebay.myriad.scheduler.*;
 import com.ebay.myriad.scheduler.event.ResourceOffersEvent;
 import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
@@ -50,6 +47,9 @@ public class ResourceOffersEventHandler implements
 
     @Inject
     private TaskUtils taskUtils;
+
+    @Inject
+    private YarnNodeCapacityManager yarnNodeCapacityManager;
 
     @Override
     public void onEvent(ResourceOffersEvent event, long sequence,
@@ -103,10 +103,7 @@ public class ResourceOffersEventHandler implements
                     }
                 }
             } else {
-                LOGGER.info("No pending tasks, declining all offers");
-                for (Offer offer : offers) {
-                    driver.declineOffer(offer.getId());
-                }
+                yarnNodeCapacityManager.addResourceOffers(offers);
             }
         } finally {
             driverOperationLock.unlock();

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadCapacityScheduler.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadCapacityScheduler.java
@@ -41,7 +41,7 @@ public class MyriadCapacityScheduler extends CapacityScheduler {
     @Override
     public void handle(SchedulerEvent event) {
         super.handle(event);
-        this.yarnSchedulerInterceptor.onEventHandled(event);
+        this.yarnSchedulerInterceptor.afterSchedulerEventHandled(event);
     }
 
 }

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadFairScheduler.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadFairScheduler.java
@@ -3,9 +3,15 @@ package com.ebay.myriad.scheduler.yarn;
 import com.ebay.myriad.scheduler.yarn.interceptor.CompositeInterceptor;
 import com.ebay.myriad.scheduler.yarn.interceptor.YarnSchedulerInterceptor;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEventType;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeStatusEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -15,11 +21,29 @@ import java.io.IOException;
  * via the {@link YarnSchedulerInterceptor} interface.
  */
 public class MyriadFairScheduler extends FairScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MyriadFairScheduler.class);
+
     private final YarnSchedulerInterceptor yarnSchedulerInterceptor;
+    private RMNodeEventHandler rmNodeEventHandler;
 
     public MyriadFairScheduler() {
         super();
         this.yarnSchedulerInterceptor = new CompositeInterceptor();
+    }
+
+    /**
+     * Register an event handler that receives {@link RMNodeEvent} events.
+     * This event handler is registered ahead of RM's own event handler for RMNodeEvents.
+     * For e.g. myriad can inspect a node's HB (RMNodeStatusEvent) before the HB is handled by
+     * RM and the scheduler.
+     *
+     * @param rmContext
+     */
+    @Override
+    public synchronized void setRMContext(RMContext rmContext) {
+        rmNodeEventHandler = new RMNodeEventHandler(yarnSchedulerInterceptor, rmContext);
+        rmContext.getDispatcher().register(RMNodeEventType.class, rmNodeEventHandler);
+        super.setRMContext(rmContext);
     }
 
     /**
@@ -40,8 +64,9 @@ public class MyriadFairScheduler extends FairScheduler {
 
     @Override
     public void handle(SchedulerEvent event) {
+        this.yarnSchedulerInterceptor.beforeSchedulerEventHandled(event);
         super.handle(event);
-        this.yarnSchedulerInterceptor.onEventHandled(event);
+        this.yarnSchedulerInterceptor.afterSchedulerEventHandled(event);
     }
 }
 

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadFifoScheduler.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/MyriadFifoScheduler.java
@@ -41,7 +41,7 @@ public class MyriadFifoScheduler extends FifoScheduler {
     @Override
     public void handle(SchedulerEvent event) {
         super.handle(event);
-        this.yarnSchedulerInterceptor.onEventHandled(event);
+        this.yarnSchedulerInterceptor.afterSchedulerEventHandled(event);
     }
 
 }

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/RMNodeEventHandler.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/RMNodeEventHandler.java
@@ -1,0 +1,25 @@
+package com.ebay.myriad.scheduler.yarn;
+
+import com.ebay.myriad.scheduler.yarn.interceptor.YarnSchedulerInterceptor;
+import org.apache.hadoop.yarn.event.EventHandler;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
+
+/**
+ * Passes the {@link RMNodeEvent} events into the {@link YarnSchedulerInterceptor}.
+ */
+public class RMNodeEventHandler implements EventHandler<RMNodeEvent> {
+    private final YarnSchedulerInterceptor interceptor;
+    private final RMContext rmContext;
+
+    public RMNodeEventHandler(YarnSchedulerInterceptor interceptor, RMContext rmContext) {
+        this.interceptor = interceptor;
+        this.rmContext = rmContext;
+    }
+
+    @Override
+    public void handle(RMNodeEvent event) {
+        interceptor.beforeRMNodeEventHandled(event, rmContext);
+
+    }
+}

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/BaseInterceptor.java
@@ -1,6 +1,8 @@
 package com.ebay.myriad.scheduler.yarn.interceptor;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEvent;
 
@@ -21,7 +23,17 @@ public class BaseInterceptor implements YarnSchedulerInterceptor {
     }
 
     @Override
-    public void onEventHandled(SchedulerEvent event) {
+    public void beforeRMNodeEventHandled(RMNodeEvent event, RMContext context) {
+
+    }
+
+    @Override
+    public void beforeSchedulerEventHandled(SchedulerEvent event) {
+
+    }
+
+    @Override
+    public void afterSchedulerEventHandled(SchedulerEvent event) {
 
     }
 }

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
@@ -3,6 +3,8 @@ package com.ebay.myriad.scheduler.yarn.interceptor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEvent;
 import org.slf4j.Logger;
@@ -64,9 +66,23 @@ public class CompositeInterceptor implements YarnSchedulerInterceptor, Intercept
     }
 
     @Override
-    public void onEventHandled(SchedulerEvent event) {
+    public void beforeRMNodeEventHandled(RMNodeEvent event, RMContext context) {
         for (YarnSchedulerInterceptor interceptor : interceptors.values()) {
-            interceptor.onEventHandled(event);
+            interceptor.beforeRMNodeEventHandled(event, context);
+        }
+    }
+
+    @Override
+    public void beforeSchedulerEventHandled(SchedulerEvent event) {
+        for (YarnSchedulerInterceptor interceptor : interceptors.values()) {
+            interceptor.beforeSchedulerEventHandled(event);
+        }
+    }
+
+    @Override
+    public void afterSchedulerEventHandled(SchedulerEvent event) {
+        for (YarnSchedulerInterceptor interceptor : interceptors.values()) {
+            interceptor.afterSchedulerEventHandled(event);
         }
     }
 }

--- a/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/YarnSchedulerInterceptor.java
+++ b/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/YarnSchedulerInterceptor.java
@@ -3,6 +3,8 @@ package com.ebay.myriad.scheduler.yarn.interceptor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.YarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.*;
@@ -24,9 +26,25 @@ public interface YarnSchedulerInterceptor {
     public void init(Configuration conf, AbstractYarnScheduler yarnScheduler) throws IOException;
 
     /**
+     * Invoked *before* {@link RMNodeImpl#handle(RMNodeEvent)}.
+     *
+     * @param event
+     * @param context
+     */
+    public void beforeRMNodeEventHandled(RMNodeEvent event, RMContext context);
+
+    /**
+     * Invoked *before* {@link YarnScheduler#handle(Event)}
+     * @param event
+     */
+    public void beforeSchedulerEventHandled(SchedulerEvent event);
+
+    /**
+
+    /**
      * Invoked *after* {@link YarnScheduler#handle(Event)}
      * @param event
      */
-    public void onEventHandled(SchedulerEvent event);
+    public void afterSchedulerEventHandled(SchedulerEvent event);
 
 }


### PR DESCRIPTION
Submitting a PR to merge the work into https://github.com/mesos/myriad/tree/issue_14 branch.

The feature currently works as follows
- Build myriad with a special "zero" profile added to myriad-config-default.yml:

```
profiles:
  zero:
    cpu: 0
    mem: 0
```
- Flexup a few NMs using /api/cluster/flexup, but with "zero" profile:

```
{
  "instances":3, "profile": "zero"
}
```
- Submit a M/R job to the Resource Manager.
- The MesosUI should show "placeholder" mesos tasks (prefixed with "yarn_") for each yarn container. The job should finish successfully (although the NMs were originally launched with 0 capacities).

![mesos_tasks_for_yarn_containers](https://cloud.githubusercontent.com/assets/3505177/7049736/d7995bf8-ddd0-11e4-850d-c59bca1fd1bf.png)
