### PR TITLE
Issue #40: Mesos now dynamically configures ports of the Node Manager

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@
 
 ## Running the Resource Manager Docker
 
-`docker run --name='myriad-resourcemanager' -t \ -v /path/to/yarn-site.xml:/myriad-conf/yarn-site.xml \ -v /path/to/myriad-config-default.yml:/myriad-conf/myriad-config-default.yml \ -e HADOOP_NAMENODE="10.100.3.237:9000" \ bgulla/myriad-resourcemanager`
+`docker run --name='myriad-resourcemanager' -t \ -v /path/to/yarn-site.xml:/myriad-conf/yarn-site.xml \ -v /path/to/myriad-config-default.yml:/myriad-conf/myriad-config-default.yml \ -e HADOOP_NAMENODE="10.100.3.237:9000" \ mesos/myriad-resourcemanager`
 
 ### Available Environment Variables
 You can also pass in custom values via docker run for the following env vars: 

--- a/docs/myriad-dev.md
+++ b/docs/myriad-dev.md
@@ -100,12 +100,40 @@ export MESOS_NATIVE_JAVA_LIBRARY=/usr/local/lib/libmesos.so
     <name>yarn.nodemanager.resource.memory-mb</name>
     <value>${nodemanager.resource.memory-mb}</value>
 </property>
+<!--These options enable dynamic port assignment by mesos -->
+<property>
+    <name>yarn.nodemanager.address</name>
+    <value>${myriad.yarn.nodemanager.address}</value>
+</property>
+<property>
+    <name>yarn.nodemanager.webapp.address</name>
+    <value>${myriad.yarn.nodemanager.webapp.address}</value>
+</property>
+<property>
+    <name>yarn.nodemanager.webapp.https.address</name>
+    <value>${myriad.yarn.nodemanager.webapp.address}</value>
+</property>
+<property>
+    <name>yarn.nodemanager.localizer.address</name>
+    <value>${myriad.yarn.nodemanager.localizer.address}</value>
+</property>
 
 <!-- Configure Myriad Scheduler here -->
 <property>
     <name>yarn.resourcemanager.scheduler.class</name>
     <value>com.ebay.myriad.scheduler.yarn.MyriadFairScheduler</value>
     <description>One can configure other scehdulers as well from following list: com.ebay.myriad.scheduler.yarn.MyriadCapacityScheduler, com.ebay.myriad.scheduler.yarn.MyriadFifoScheduler</description>
+</property>
+
+```
+
+* Add following to ```$YARN_HOME/etc/hadoop/mapred-site.xml```:
+
+```xml
+<!--This option enables dynamic port assignment by mesos -->
+<property>
+    <name>mapreduce.shuffle.port</name>
+    <value>${myriad.mapreduce.shuffle.port}</value>
 </property>
 ```
 

--- a/docs/myriad-remote-distribution-configuration.md
+++ b/docs/myriad-remote-distribution-configuration.md
@@ -52,7 +52,7 @@ Create the tarball and place it in hdfs:
 ```
 cd ~
 sudo cp -rp /opt/hadoop-2.5.0 .
-sudo rm hadoop-2.5.0/etc/hadoop/*.xml
+sudo rm hadoop-2.5.0/etc/hadoop/yarn-site.xml
 sudo tar -zcpf ~/hadoop-2.5.0.tar.gz hadoop-2.5.0
 hadoop fs -put ~/hadoop-2.5.0.tar.gz /dist
 ```

--- a/myriad-commons/src/main/java/com/ebay/myriad/executor/NMTaskConfig.java
+++ b/myriad-commons/src/main/java/com/ebay/myriad/executor/NMTaskConfig.java
@@ -11,6 +11,11 @@ public class NMTaskConfig {
     private Long advertisableMem;
     private String jvmOpts;
     private Boolean cgroups;
+    private Long rpcPort;
+    private Long localizerPort;
+    private Long webAppHttpPort;
+    private Long shufflePort;
+
     private Map<String, String> yarnEnvironment;
 
     public String getYarnHome() {
@@ -59,6 +64,38 @@ public class NMTaskConfig {
 
     public void setYarnEnvironment(Map<String, String> yarnEnvironment) {
         this.yarnEnvironment = yarnEnvironment;
+    }
+
+    public Long getRpcPort() {
+        return rpcPort;
+    }
+
+    public void setRpcPort(long port) {
+        rpcPort = port;
+    }
+
+    public Long gettWebAppHttpPort() {
+        return webAppHttpPort;
+    }
+
+    public void setWebAppHttpPort(Long port) {
+        webAppHttpPort = port;
+    }
+
+    public Long getLocalizerPort() {
+        return localizerPort;
+    }
+
+    public void setLocalizerPort(Long localizerPort) {
+        this.localizerPort = localizerPort;
+    }
+
+    public Long getShufflePort() {
+        return shufflePort;
+    }
+
+    public void setShufflePort(Long shufflePort) {
+        this.shufflePort = shufflePort;
     }
 
 }

--- a/myriad-executor/src/main/java/com/ebay/myriad/executor/MyriadExecutor.java
+++ b/myriad-executor/src/main/java/com/ebay/myriad/executor/MyriadExecutor.java
@@ -12,7 +12,6 @@ import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
-import org.apache.mesos.Protos.TaskStatus.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +61,16 @@ public class MyriadExecutor implements Executor {
     public static final String KEY_NM_RESOURCE_CPU_VCORES = "nodemanager.resource.cpu-vcores";
 
     public static final String KEY_NM_RESOURCE_MEM_MB = "nodemanager.resource.memory-mb";
+
+    public static final String KEY_NM_ADDRESS = "myriad.yarn.nodemanager.address";
+
+    public static final String KEY_NM_LOCALIZER_ADDRESS = "myriad.yarn.nodemanager.localizer.address";
+
+    public static final String KEY_NM_WEBAPP_ADDRESS = "myriad.yarn.nodemanager.webapp.address";
+
+    public static final String KEY_NM_SHUFFLE_PORT = "myriad.mapreduce.shuffle.port";
+
+
 
     /**
      * Allot 10% more memory to account for JVM overhead.
@@ -115,7 +124,7 @@ public class MyriadExecutor implements Executor {
     public void launchTask(final ExecutorDriver driver, final TaskInfo task) {
         new Thread(new Runnable() {
             public void run() {
-                Builder statusBuilder = TaskStatus.newBuilder()
+                TaskStatus.Builder statusBuilder = TaskStatus.newBuilder()
                         .setTaskId(task.getTaskId());
                 try {
                     NMTaskConfig taskConfig = GSON.fromJson(task.getData().toStringUtf8(), NMTaskConfig.class);
@@ -209,6 +218,11 @@ public class MyriadExecutor implements Executor {
         }
         envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_RESOURCE_CPU_VCORES, taskConfig.getAdvertisableCpus() + "");
         envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_RESOURCE_MEM_MB, taskConfig.getAdvertisableMem() + "");
+        envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_ADDRESS, "0.0.0.0:" + taskConfig.getRpcPort().toString() + "");
+        envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_LOCALIZER_ADDRESS, "0.0.0.0:" + taskConfig.getLocalizerPort().toString() + "");
+        envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_WEBAPP_ADDRESS, "0.0.0.0:" + taskConfig.gettWebAppHttpPort().toString() + "");
+        envNMOptions += String.format(PROPERTY_FORMAT, KEY_NM_SHUFFLE_PORT, taskConfig.getShufflePort().toString() + "");
+
         return envNMOptions;
     }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMPorts.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMPorts.java
@@ -1,0 +1,65 @@
+package com.ebay.myriad.scheduler;
+
+import com.google.common.base.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class for dynamically assigning ports to nodemanager
+ */
+public class NMPorts {
+    private static final String NM_RPC_PORT_KEY = "nm.rpc.port";
+    private static final String NM_LOCALIZER_PORT_KEY = "nm.localizer.port";
+    private static final String NM_WEBAPP_HTTP_PORT_KEY = "nm.webapp.http.port";
+    private static final String NM_HTTP_SHUFFLE_PORT_KEY = "nm.http.shuffle.port";
+
+    private static final String [] NM_PORT_KEYS = {
+            NM_RPC_PORT_KEY,
+            NM_LOCALIZER_PORT_KEY,
+            NM_WEBAPP_HTTP_PORT_KEY,
+            NM_HTTP_SHUFFLE_PORT_KEY
+    };
+
+    private Map<String, Long> portsMap = new HashMap<>(NM_PORT_KEYS.length);
+
+    public NMPorts(Long [] ports){
+        Preconditions.checkState(ports.length == NM_PORT_KEYS.length, "NMPorts: array \"ports\" is of unexpected length");
+        for (int i = 0; i < NM_PORT_KEYS.length; i++) {
+            portsMap.put(NM_PORT_KEYS[i], ports[i]);
+        }
+    }
+
+    public long getRpcPort() {
+        return portsMap.get(NM_RPC_PORT_KEY);
+    }
+
+    public long getLocalizerPort() {
+        return portsMap.get(NM_LOCALIZER_PORT_KEY);
+    }
+
+    public long getWebAppHttpPort() {
+        return portsMap.get(NM_WEBAPP_HTTP_PORT_KEY);
+    }
+
+    public long getShufflePort() {
+        return portsMap.get(NM_HTTP_SHUFFLE_PORT_KEY);
+    }
+
+    public static int expectedNumPorts() {
+        return NM_PORT_KEYS.length;
+    }
+
+    /**
+     * @return a string representation of NMPorts
+     */
+    @Override
+    public String toString(){
+        StringBuilder sb = new StringBuilder().append("{");
+        for (String key: NM_PORT_KEYS) {
+            sb.append(key).append(": ").append(portsMap.get(key).toString()).append(", ");
+        }
+        sb.replace(sb.length() - 2, sb.length(), "}");
+        return sb.toString();
+    }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -80,6 +80,7 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
                         NodeTask taskToLaunch = schedulerState
                                 .getTask(pendingTaskId);
                         NMProfile profile = taskToLaunch.getProfile();
+
                         if (matches(offer, profile)
                                 && SchedulerUtils.isUniqueHostname(offer,
                                 schedulerState.getActiveTasks())) {
@@ -124,54 +125,34 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     }
 
     private boolean matches(Offer offer, NMProfile profile) {
-        double cpus = -1;
-        double mem = -1;
-        int ports = 0;
+        Map<String, Object> results = new HashMap<String, Object>(5);
+
         for (Resource resource : offer.getResourcesList()) {
-            if (resource.getName().equals("cpus")) {
-                if (resource.getType().equals(Value.Type.SCALAR)) {
-                    cpus = resource.getScalar().getValue();
-                } else {
-                    LOGGER.error("Cpus resource was not a scalar: {}", resource
-                            .getType().toString());
-                }
-            } else if (resource.getName().equals("mem")) {
-                if (resource.getType().equals(Value.Type.SCALAR)) {
-                    mem = resource.getScalar().getValue();
-                } else {
-                    LOGGER.error("Mem resource was not a scalar: {}", resource
-                            .getType().toString());
-                }
-            } else if (resource.getName().equals("disk")) {
-                LOGGER.warn("Ignoring disk resources from offer");
-            } else if (resource.getName().equals("ports")) {
-                if (resource.getType().equals(Value.Type.RANGES)) {
-                    Value.Ranges ranges =  resource.getRanges();
-                    for (Value.Range range : ranges.getRangeList()) {
-                        if (range.getBegin() < range.getEnd()) {
-                            ports += range.getEnd() - range.getBegin() + 1;
-                        }
-                    }
-                } else {
-                    LOGGER.error("ports resource was not Ranges: {}", resource
-                            .getType().toString());
-                }
+            if (resourceEvaluators.containsKey(resource.getName())) {
+                resourceEvaluators.get(resource.getName()).eval(resource, results);
             } else {
                 LOGGER.warn("Ignoring unknown resource type: {}",
                         resource.getName());
             }
         }
+        double cpus = (Double) results.get("cpus");
+        double mem = (Double) results.get("mem");
+        int ports = (Integer) results.get("ports");
 
-        if (cpus < 0) {
-            LOGGER.error("No cpus resource present");
-        }
-        if (mem < 0) {
-            LOGGER.error("No mem resource present");
-        }
-        if (ports < 0) {
-            LOGGER.error("No port resources present");
-        }
+        checkResource(cpus < 0, "cpus");
+        checkResource(mem < 0, "mem");
+        checkResource(ports < 0, "port");
 
+        return checkAggregates(offer, profile, ports, cpus, mem);
+    }
+
+    private void checkResource(boolean fail, String resource) {
+        if (fail) {
+            LOGGER.info("No " + resource + " resources present");
+        }
+    }
+
+    private boolean checkAggregates(Offer offer, NMProfile profile, int ports, double cpus, double mem) {
         Map<String, String> requestAttributes = new HashMap<>();
 
         if (taskUtils.getAggregateCpus(profile) <= cpus
@@ -184,5 +165,59 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
                     taskUtils.getAggregateCpus(profile), taskUtils.getAggregateMemory(profile), ports);
             return false;
         }
+    }
+
+    private static Double scalarToDouble(Resource resource, String id) {
+        Double value = new Double(0.0);
+        if (resource.getType().equals(Value.Type.SCALAR)) {
+            value = new Double(resource.getScalar().getValue());
+        } else {
+            LOGGER.error(id + " resource was not a scalar: {}", resource
+                    .getType().toString());
+        }
+        return value;
+    }
+
+    private interface EvalResources {
+        public void eval(Resource resource, Map<String, Object>results);
+    }
+
+    private static Map<String, EvalResources> resourceEvaluators;
+
+    static {
+        resourceEvaluators = new HashMap<String, EvalResources>(4);
+        resourceEvaluators.put("cpus", new EvalResources() {
+            public void eval(Resource resource, Map<String, Object> results) {
+                results.put("cpus", scalarToDouble(resource, "cpus"));
+            }
+        });
+        resourceEvaluators.put("mem", new EvalResources() {
+            public void eval(Resource resource, Map<String, Object> results) {
+                results.put("mem", scalarToDouble(resource, "mem"));
+            }
+        });
+        resourceEvaluators.put("disk", new EvalResources() {
+            public void eval(Resource resource, Map<String, Object> results) {
+            }
+        });
+        resourceEvaluators.put("ports", new EvalResources() {
+            public void eval(Resource resource, Map<String, Object> results) {
+                int ports = 0;
+                if (resource.getType().equals(Value.Type.RANGES)) {
+                    Value.Ranges ranges = resource.getRanges();
+                    for (Value.Range range : ranges.getRangeList()) {
+                        if (range.getBegin() < range.getEnd()) {
+                            ports += range.getEnd() - range.getBegin() + 1;
+                        }
+                    }
+
+                } else {
+                    LOGGER.error("ports resource was not Ranges: {}", resource
+                            .getType().toString());
+
+                }
+                results.put("ports", Integer.valueOf(ports));
+            }
+        });
     }
 }


### PR DESCRIPTION
Mesos now dynamically configures ports of the Node Manager.  This addresses Issue #40 completely and Issue #45 partially.

This is done by first checking if three ports are available in the resource offer, if so they are added the TaskInfo object and passed to the executor via NMTaskConfig. 

Added `NMPorts.java`, an immutable helper class used by `TaskFactory.java`, essentially a Tuple Object.

Tested on one node cluster, map reduce jobs complete as expected, all NM web ports are linked to the RM as expected.

Updated `myriad-dev.md` to reflect changes.  Other than the modifications to `yarn-site.xml` no other changes are needed.  If the modifications are left out, the node manage will use the default ports.
