### PR TITLE
Support unit testing of myriad scheduler.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ subprojects {
         myriadExecutorConf
         myriadExecutorConf.transitive = false
         // exclude hadoop/yarn deps for 'runtime'
-        runtime.exclude group: 'org.apache.hadoop', module: '*'
+        // TODO (Kannan Rajah) Exclude only while packaging
+        //runtime.exclude group: 'org.apache.hadoop', module: '*'
     }
 
     repositories {

--- a/myriad-scheduler/build.gradle
+++ b/myriad-scheduler/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 	compile "com.fasterxml.jackson.core:jackson-databind:2.5.1"
 	compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.5.1"
 	compile "org.apache.curator:curator-framework:2.7.1"
-
+  testCompile "org.apache.hadoop:hadoop-yarn-server-resourcemanager:${hadoopVer}:tests"
 }
 
 // copies dependencies to build/libs dir

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/MesosModule.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/MesosModule.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2012-2014 eBay Software Foundation, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.ebay.myriad;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.mesos.MesosSchedulerDriver;
+import org.apache.mesos.Protos.Credential;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.FrameworkInfo;
+import org.apache.mesos.Protos.FrameworkInfo.Builder;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.state.State;
+import org.apache.mesos.state.ZooKeeperState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.scheduler.MyriadDriver;
+import com.ebay.myriad.scheduler.MyriadScheduler;
+import com.ebay.myriad.state.SchedulerState;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * Guice Module for Mesos objects.
+ */
+public class MesosModule extends AbstractModule {
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      MesosModule.class);
+
+  public MesosModule() {
+  }
+
+  @Override
+  protected void configure() {
+    bind(MyriadDriver.class).in(Scopes.SINGLETON);
+  }
+
+  @Provides
+  @Singleton
+  SchedulerDriver providesSchedulerDriver(
+      MyriadScheduler scheduler,
+      MyriadConfiguration cfg,
+      SchedulerState schedulerState) {
+
+    Builder frameworkInfoBuilder = FrameworkInfo.newBuilder().setUser("")
+      .setName(cfg.getFrameworkName())
+      .setCheckpoint(cfg.isCheckpoint())
+      .setFailoverTimeout(cfg.getFrameworkFailoverTimeout());
+
+    if (StringUtils.isNotEmpty(cfg.getFrameworkRole())) {
+      frameworkInfoBuilder.setRole(cfg.getFrameworkRole());
+    }
+
+    FrameworkID frameworkId;
+    try {
+      frameworkId = schedulerState.getMyriadState().getFrameworkID();
+      if (frameworkId != null) {
+        LOGGER.info("Attempting to re-register with frameworkId: {}", frameworkId.getValue());
+        frameworkInfoBuilder.setId(frameworkId);
+      }
+    } catch (InterruptedException | ExecutionException | InvalidProtocolBufferException e) {
+      LOGGER.error("Error fetching frameworkId", e);
+      throw new RuntimeException(e);
+    }
+
+    String mesosAuthenticationPrincipal = cfg.getMesosAuthenticationPrincipal();
+    String mesosAuthenticationSecretFilename = cfg.getMesosAuthenticationSecretFilename();
+    if (StringUtils.isNotEmpty(mesosAuthenticationPrincipal)) {
+      frameworkInfoBuilder.setPrincipal(mesosAuthenticationPrincipal);
+
+      Credential.Builder credentialBuilder = Credential.newBuilder();
+      credentialBuilder.setPrincipal(mesosAuthenticationPrincipal);
+      if (StringUtils.isNotEmpty(mesosAuthenticationSecretFilename)) {
+        try  {
+          credentialBuilder.setSecret(ByteString.readFrom(
+                new FileInputStream(mesosAuthenticationSecretFilename)));
+        } catch (FileNotFoundException ex) {
+          LOGGER.error("Mesos authentication secret file was not found", ex);
+          throw new RuntimeException(ex);
+        } catch (IOException ex) {
+          LOGGER.error("Error reading Mesos authentication secret file", ex);
+          throw new RuntimeException(ex);
+        }
+      }
+      return new MesosSchedulerDriver(scheduler, frameworkInfoBuilder.build(),
+          cfg.getMesosMaster(), credentialBuilder.build());
+    } else {
+      return new MesosSchedulerDriver(scheduler,
+          frameworkInfoBuilder.build(), cfg.getMesosMaster());
+    }
+  }
+
+  @Provides
+  @Singleton
+  State providesStateStore(MyriadConfiguration cfg) {
+    return new ZooKeeperState(
+        cfg.getZkServers(),
+        cfg.getZkTimeout(),
+        TimeUnit.MILLISECONDS,
+        "/myriad/" + cfg.getFrameworkName());
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/MyriadModule.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/MyriadModule.java
@@ -18,7 +18,6 @@ package com.ebay.myriad;
 import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.policy.LeastAMNodesFirstPolicy;
 import com.ebay.myriad.policy.NodeScaleDownPolicy;
-import com.ebay.myriad.scheduler.MyriadDriver;
 import com.ebay.myriad.scheduler.MyriadDriverManager;
 import com.ebay.myriad.scheduler.MyriadScheduler;
 import com.ebay.myriad.scheduler.NMHeartBeatHandler;
@@ -40,11 +39,10 @@ import com.google.inject.Singleton;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
-import org.apache.mesos.state.ZooKeeperState;
+import org.apache.mesos.state.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
 
 /**
  * Guice Module for Myriad
@@ -74,7 +72,6 @@ public class MyriadModule extends AbstractModule {
         bind(Configuration.class).toInstance(hadoopConf);
         bind(AbstractYarnScheduler.class).toInstance(yarnScheduler);
         bind(InterceptorRegistry.class).toInstance(interceptorRegistry);
-        bind(MyriadDriver.class).in(Scopes.SINGLETON);
         bind(MyriadDriverManager.class).in(Scopes.SINGLETON);
         bind(MyriadScheduler.class).in(Scopes.SINGLETON);
         bind(NMProfileManager.class).in(Scopes.SINGLETON);
@@ -93,14 +90,11 @@ public class MyriadModule extends AbstractModule {
 
     @Provides
     @Singleton
-    SchedulerState providesSchedulerState(MyriadConfiguration cfg) {
+    SchedulerState providesSchedulerState(MyriadConfiguration cfg,
+        State stateStore) {
+
         LOGGER.debug("Configuring SchedulerState provider");
-        ZooKeeperState zkState = new ZooKeeperState(
-                cfg.getZkServers(),
-                cfg.getZkTimeout(),
-                TimeUnit.MILLISECONDS,
-                "/myriad/" + cfg.getFrameworkName());
-        MyriadState state = new MyriadState(zkState);
+        MyriadState state = new MyriadState(stateStore);
         return new SchedulerState(state);
     }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadDriver.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadDriver.java
@@ -15,83 +15,25 @@
  */
 package com.ebay.myriad.scheduler;
 
-import com.ebay.myriad.configuration.MyriadConfiguration;
-import com.ebay.myriad.state.SchedulerState;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-import org.apache.commons.lang.StringUtils;
-import org.apache.mesos.MesosSchedulerDriver;
-import org.apache.mesos.Protos.Credential;
-import org.apache.mesos.Protos.FrameworkID;
-import org.apache.mesos.Protos.FrameworkInfo;
-import org.apache.mesos.Protos.FrameworkInfo.Builder;
+import javax.inject.Inject;
+
 import org.apache.mesos.Protos.Status;
 import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 /**
- * The driver for the Myriad scheduler
+ * Driver for Myriad scheduler.
  */
 public class MyriadDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(MyriadDriver.class);
 
-    private final MesosSchedulerDriver driver;
+    private final SchedulerDriver driver;
 
     @Inject
-    public MyriadDriver(final MyriadScheduler scheduler,
-                        final MyriadConfiguration cfg,
-                        final SchedulerState schedulerState) {
-        Builder frameworkInfoBuilder = FrameworkInfo.newBuilder().setUser("")
-                .setName(cfg.getFrameworkName())
-                .setCheckpoint(cfg.isCheckpoint())
-                .setFailoverTimeout(cfg.getFrameworkFailoverTimeout());
-
-        if (StringUtils.isNotEmpty(cfg.getFrameworkRole())) {
-            frameworkInfoBuilder.setRole(cfg.getFrameworkRole());
-        }
-
-        FrameworkID frameworkId;
-        try {
-            frameworkId = schedulerState.getMyriadState().getFrameworkID();
-            if (frameworkId != null) {
-                LOGGER.info("Attempting to re-register with frameworkId: {}", frameworkId.getValue());
-                frameworkInfoBuilder.setId(frameworkId);
-            }
-        } catch (InterruptedException | ExecutionException | InvalidProtocolBufferException e) {
-            LOGGER.error("Error fetching frameworkId", e);
-            throw new RuntimeException(e);
-        }
-
-        String mesosAuthenticationPrincipal = cfg.getMesosAuthenticationPrincipal();
-        String mesosAuthenticationSecretFilename = cfg.getMesosAuthenticationSecretFilename();
-        if (StringUtils.isNotEmpty(mesosAuthenticationPrincipal)) {
-            frameworkInfoBuilder.setPrincipal(mesosAuthenticationPrincipal);
-
-            Credential.Builder credentialBuilder = Credential.newBuilder();
-            credentialBuilder.setPrincipal(mesosAuthenticationPrincipal);
-            if (StringUtils.isNotEmpty(mesosAuthenticationSecretFilename)) {
-                try  {
-                    credentialBuilder.setSecret(ByteString.readFrom(new FileInputStream(mesosAuthenticationSecretFilename)));
-                } catch (FileNotFoundException ex) {
-                    LOGGER.error("Mesos authentication secret file was not found", ex);
-                    throw new RuntimeException(ex);
-                } catch (IOException ex) {
-                    LOGGER.error("Error reading Mesos authentication secret file", ex);
-                    throw new RuntimeException(ex);
-                }
-            }
-            this.driver = new MesosSchedulerDriver(scheduler, frameworkInfoBuilder.build(), cfg.getMesosMaster(), credentialBuilder.build());
-        } else {
-            this.driver = new MesosSchedulerDriver(scheduler,
-                    frameworkInfoBuilder.build(), cfg.getMesosMaster());
-        }
+    public MyriadDriver(SchedulerDriver driver) {
+      this.driver = driver;
     }
 
     public Status start() {
@@ -115,7 +57,7 @@ public class MyriadDriver {
         return status;
     }
 
-    public MesosSchedulerDriver getDriver() {
+    public SchedulerDriver getDriver() {
         return driver;
     }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
@@ -42,13 +42,8 @@ public class CompositeInterceptor implements YarnSchedulerInterceptor, Intercept
 
     @Override
     public void register(YarnSchedulerInterceptor interceptor) {
-        if (interceptors.containsKey(interceptor.getClass())) {
-            throw new RuntimeException("More than one instance of " +
-                interceptor.getClass().getName() + " is being registered with " + this.getClass());
-        } else {
-            interceptors.put(interceptor.getClass(), interceptor);
-            LOGGER.info("Registered {} into the registry.", interceptor.getClass().getName());
-        }
+      interceptors.put(interceptor.getClass(), interceptor);
+      LOGGER.info("Registered {} into the registry.", interceptor.getClass().getName());
     }
 
     /**

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/MyriadState.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/MyriadState.java
@@ -1,9 +1,10 @@
 package com.ebay.myriad.state;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+
 import org.apache.mesos.Protos;
+import org.apache.mesos.state.State;
 import org.apache.mesos.state.Variable;
-import org.apache.mesos.state.ZooKeeperState;
 
 import java.util.concurrent.ExecutionException;
 
@@ -11,16 +12,16 @@ import java.util.concurrent.ExecutionException;
  * Model that represents the state of Myriad
  */
 public class MyriadState {
-    private static final String KEY_FRAMEWORK_ID = "frameworkId";
+    public static final String KEY_FRAMEWORK_ID = "frameworkId";
 
-    private ZooKeeperState zkState;
+    private State stateStore;
 
-    public MyriadState(ZooKeeperState zkState) {
-        this.zkState = zkState;
+    public MyriadState(State stateStore) {
+        this.stateStore = stateStore;
     }
 
     public Protos.FrameworkID getFrameworkID() throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
-        byte[] frameworkId = zkState.fetch(KEY_FRAMEWORK_ID).get().value();
+        byte[] frameworkId = stateStore.fetch(KEY_FRAMEWORK_ID).get().value();
 
         if (frameworkId.length > 0) {
             return Protos.FrameworkID.parseFrom(frameworkId);
@@ -30,8 +31,8 @@ public class MyriadState {
     }
 
     public void setFrameworkId(Protos.FrameworkID newFrameworkId) throws InterruptedException, ExecutionException {
-        Variable frameworkId = zkState.fetch(KEY_FRAMEWORK_ID).get();
+        Variable frameworkId = stateStore.fetch(KEY_FRAMEWORK_ID).get();
         frameworkId = frameworkId.mutate(newFrameworkId.toByteArray());
-        zkState.store(frameworkId).get();
+        stateStore.store(frameworkId).get();
     }
 }

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/MesosModule.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/MesosModule.java
@@ -1,0 +1,70 @@
+package com.ebay.myriad;
+
+import java.util.concurrent.FutureTask;
+
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Status;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.state.State;
+import org.apache.mesos.state.Variable;
+import org.mockito.Mockito;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.scheduler.MyriadDriver;
+import com.ebay.myriad.scheduler.MyriadScheduler;
+import com.ebay.myriad.state.MyriadState;
+import com.ebay.myriad.state.SchedulerState;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+/**
+ * Guice Module for Mesos objects.
+ */
+public class MesosModule extends AbstractModule {
+  public MesosModule() {
+  }
+
+  @Override
+  protected void configure() {
+    bind(MyriadDriver.class).in(Scopes.SINGLETON);
+  }
+
+  @Provides
+  @Singleton
+  SchedulerDriver providesSchedulerDriver(
+      MyriadScheduler scheduler,
+      MyriadConfiguration cfg,
+      SchedulerState schedulerState) {
+
+    SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
+    Mockito.when(driver.start()).thenReturn(Status.DRIVER_RUNNING);
+    Mockito.when(driver.abort()).thenReturn(Status.DRIVER_ABORTED);
+
+    return driver;
+  }
+
+  @Provides
+  @Singleton
+  State providesStateStore(MyriadConfiguration cfg) {
+    State stateStore = Mockito.mock(State.class);
+
+    Runnable dummyTask = new Runnable() {
+      public void run() {
+      }
+    };
+
+    Variable var = Mockito.mock(Variable.class);
+    Protos.FrameworkID id = Protos.FrameworkID.newBuilder()
+      .setValue("1").build();
+
+    Mockito.when(var.value()).thenReturn(id.toByteArray());
+    FutureTask<Variable> futureTask = new FutureTask<Variable>(dummyTask, var);
+    futureTask.run();
+    Mockito.when(stateStore.fetch(MyriadState.KEY_FRAMEWORK_ID))
+      .thenReturn(futureTask);
+
+    return stateStore;
+  }
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestMyriadScheduler.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestMyriadScheduler.java
@@ -1,0 +1,109 @@
+package com.ebay.myriad.scheduler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.event.AsyncDispatcher;
+import org.apache.hadoop.yarn.server.resourcemanager.MockNodes;
+import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeAddedSchedulerEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeRemovedSchedulerEvent;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
+import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ebay.myriad.Main;
+import com.ebay.myriad.scheduler.yarn.MyriadFairScheduler;
+import com.google.inject.Injector;
+
+/**
+ * Tests myriad scheduler.
+ */
+public class TestMyriadScheduler {
+  protected Configuration conf;
+  protected FairScheduler scheduler;
+  protected ResourceManager resourceManager;
+
+  @Before
+  public void setUp() throws IOException {
+    scheduler = new MyriadFairScheduler();
+    conf = createConfiguration();
+    resourceManager = new ResourceManager();
+    resourceManager.init(conf);
+
+    // TODO: This test should really be using MockRM. For now starting stuff
+    // that is needed at a bare minimum.
+    ((AsyncDispatcher) resourceManager.getRMContext().getDispatcher()).start();
+    resourceManager.getRMContext().getStateStore().start();
+
+    // to initialize the master key
+    resourceManager.getRMContext().getContainerTokenSecretManager().rollMasterKey();
+
+    scheduler.setRMContext(resourceManager.getRMContext());
+    scheduler.init(conf);
+    scheduler.start();
+  }
+
+  @After
+  public void tearDown() {
+    if (scheduler != null) {
+      scheduler.stop();
+      scheduler = null;
+    }
+
+    if (resourceManager != null) {
+      resourceManager.stop();
+      resourceManager = null;
+    }
+  }
+
+  public Configuration createConfiguration() {
+    Configuration conf = new YarnConfiguration();
+    conf.setClass(YarnConfiguration.RM_SCHEDULER, FairScheduler.class,
+        ResourceScheduler.class);
+    conf.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 0);
+    conf.setInt(FairSchedulerConfiguration.RM_SCHEDULER_INCREMENT_ALLOCATION_MB,
+        1024);
+    conf.setInt(YarnConfiguration.RM_SCHEDULER_MAXIMUM_ALLOCATION_MB, 10240);
+    return conf;
+  }
+
+  @Test
+  public void testNodeStore() throws Exception {
+    Injector injector = Main.getInjector();
+    // TODO (Kannan Rajah) Find a better way to inject instances
+    NodeStore nodeStore = injector.getInstance(NodeStore.class);
+
+    // Add a node
+    RMNode node1 =
+        MockNodes
+            .newNodeInfo(1, Resources.createResource(1024), 1, "127.0.0.1");
+    NodeAddedSchedulerEvent nodeEvent1 = new NodeAddedSchedulerEvent(node1);
+    scheduler.handle(nodeEvent1);
+    assertEquals(1024, scheduler.getClusterResource().getMemory());
+
+    assertNotNull(nodeStore.getNode("127.0.0.1"));
+
+    // Add another node
+    RMNode node2 =
+        MockNodes.newNodeInfo(1, Resources.createResource(512), 2, "127.0.0.2");
+    NodeAddedSchedulerEvent nodeEvent2 = new NodeAddedSchedulerEvent(node2);
+    scheduler.handle(nodeEvent2);
+    assertEquals(1536, scheduler.getClusterResource().getMemory());
+
+    // Remove the first node
+    NodeRemovedSchedulerEvent nodeEvent3 = new NodeRemovedSchedulerEvent(node1);
+    scheduler.handle(nodeEvent3);
+    assertEquals(512, scheduler.getClusterResource().getMemory());
+  }
+}
+


### PR DESCRIPTION
- TestMyriadScheduler: Basic unit test to verify that myriad scheduler can be
  launched from unit testing env.
- MesosModule: Guice module to handle mesos related classes.
  There is one class under src/main and another src/test.
  By separating mesos related classes to its own module, we can inject mock
  implementations in unit test by overriding the src/main version with src/test
  version. We can thereby avoid requring mesos.so, a real mesos cluster for unit
  testing.
- Moved the code to create MesosSchedulerDriver out of MyriadDriver and into
  MesosModule. This is needed to inject a mock implementation for testing.

TODO:
- Need to figure out how to access Guice created objects in unit test. Right
  now, there is a gross hack in Main.java.
- Expand TestMyriadScheduler with actual unit tests :)
