### PR TITLE
Minor comment typos in shutdown.sh script.

### DIFF
--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,10 +1,10 @@
 set -e
 
-# Start HistoryServer
+# Stop HistoryServer
 sudo -u hduser sh -c '/usr/local/hadoop/sbin/mr-jobhistory-daemon.sh stop historyserver'
 
-# Start DataNode
+# Stop DataNode
 sudo -u hduser sh -c '/usr/local/hadoop/sbin/hadoop-daemons.sh stop datanode'
 
-# Start NameNode
+# Stop NameNode
 sudo -u hduser sh -c '/usr/local/hadoop/sbin/hadoop-daemon.sh stop namenode'


### PR DESCRIPTION
Typo in comments, It Should be 'Stop' instead of 'Start'. Thanks.
