### PR TITLE
Flex APIs / NM Placement

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -10,33 +10,59 @@
 ## Cluster API
 
 ### PUT /api/cluster/flexup
-Expands the size of the cluster
+Expands the size of the YARN cluster
 
-Request:
+Launch a Node Manager with ```small``` profile on **ANY HOST** in the Mesos cluster:
 ```json
 {
   "instances":1, "profile": "small"
 }
 ```
-
-Response:
-```
-200 OK
-```
-
-### PUT /api/cluster/flexdown
-Shrinks the size of cluster
-
-Request:
+Launch 4 Node Managers with ```large``` profile **ONLY on hosts ```host-120 through host-129```**:
 ```json
 {
-  "instances":1
+  "instances":4, "profile": "large", "constraints": ["hostname LIKE host-12[0-9].example.com"]
+}
+```
+
+Launch 2 Node Managers with ```zero``` profile **ONLY on hosts sharing a common Mesos [slave attribute](http://mesos.apache.org/documentation/attributes-resources)**
+```json
+{
+  "instances":2, "profile": "zero", "constraints": ["hdfs LIKE true"]
 }
 ```
 
 Response:
 ```
-200 OK
+202 ACCEPTED
+```
+
+### PUT /api/cluster/flexdown
+Shrinks the size of the YARN cluster
+
+Shutdown a Node Manager with ```small``` profile running on **ANY HOST** in the Mesos cluster:
+```json
+{
+  "instances":1, "profile": "small"
+}
+```
+Shutdown 4 Node Managers with ```large``` profile running **ONLY on hosts ```host-120 through host-129```**:
+```json
+{
+  "instances":4, "profile": "large", "constraints": ["hostname LIKE host-12[0-9].example.com"]
+}
+```
+
+Shutdown 2 Node Managers with ```zero``` profile running **ONLY on hosts sharing a common Mesos [slave attribute](http://mesos.apache.org/documentation/attributes-resources)**
+```json
+{
+  "instances":2, "profile": "zero", "constraints": ["hdfs LIKE true"]
+}
+```
+
+Response:
+```
+202 ACCEPTED
 ```
 
 ## State API
@@ -46,18 +72,18 @@ Response:
 Response:
 ```json
 {
-  "pendingTasks":[
-
-  ],
-  "stagingTasks":[
-
-  ],
-  "activeTasks":[
-
-  ],
-  "killableTasks":[
-
-  ]
+    "pendingTasks": [
+        "nm.zero.e9c65a2a-5b05-4459-ab0d-e9bb12c529d4",
+        "nm.zero.394fe61c-4b42-40d2-8e87-bf199e644d40",
+        "nm.zero.1354e9cc-356a-4dd9-ae1d-d28ee930266c"
+    ],
+    "stagingTasks": [],
+    "activeTasks": [
+        "nm.zero.324592be-b5c5-4a6f-b3de-29602d8d30e8",
+        "nm.zero.849335b7-630d-4652-bf49-f8a3e25f72e0",
+        "nm.medium.f6938f3b-c4e5-476a-b9a8-ce8995d2ef6c"
+    ],
+    "killableTasks": []
 }
 ```
 ## Configuration API
@@ -72,7 +98,17 @@ Sample Response:
     "frameworkFailoverTimeout": 43200000,
     "frameworkName": "MyriadAlpha",
     "frameworkRole": "",
+    "frameworkUser": {
+        "present": true
+    },
+    "frameworkSuperUser": {
+        "present": true
+    },
     "profiles": {
+        "zero": {
+            "cpu": "0",
+            "mem": "0"
+        },
         "small": {
             "cpu": "1",
             "mem": "1100"
@@ -86,22 +122,23 @@ Sample Response:
             "mem": "4096"
         }
     },
+    "nmInstances": {
+        "medium": 1
+    },
     "rebalancer": false,
     "nativeLibrary": "/usr/local/lib/libmesos.so",
     "zkServers": "10.10.30.131:5181",
     "zkTimeout": 20000,
     "restApiPort": 8192,
     "yarnEnvironment": {
-        "YARN_HOME": "/opt/mapr/hadoop/hadoop-2.5.1/",
-        "YARN_NODEMANAGER_OPTS": "-Dyarn.nodemanager.resources.io-spindles=4.0 -Dyarn.resourcemanager.hostname=10.10.30.132"
+        "YARN_HOME": "/opt/mapr/hadoop/hadoop-2.7.0/",
+        "YARN_NODEMANAGER_OPTS": "-Dnodemanager.resource.io-spindles=4.0"
     },
     "mesosAuthenticationPrincipal": "",
     "mesosAuthenticationSecretFilename": "",
+    "haenabled": true,
     "nodeManagerConfiguration": {
         "jvmMaxMemoryMB": {
-            "present": true
-        },
-        "user": {
             "present": true
         },
         "cpus": {
@@ -118,7 +155,10 @@ Sample Response:
         "jvmMaxMemoryMB": {
             "present": true
         },
-        "path": "file:///root/myriad-executor-runnable-0.0.1.jar"
+        "path": "file:///root/myriad-executor-runnable-0.0.1.jar",
+        "nodeManagerUri": {
+            "present": false
+        }
     }
 }
 ```

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
@@ -187,7 +187,7 @@ public class Main {
       MyriadOperations myriadOperations = injector.getInstance(MyriadOperations.class);
       NMProfileManager profileManager = injector.getInstance(NMProfileManager.class);
       for (Map.Entry<String, Integer> entry : nmInstances.entrySet()) {
-        myriadOperations.flexUpCluster(profileManager.get(entry.getKey()), entry.getValue());
+        myriadOperations.flexUpCluster(profileManager.get(entry.getKey()), entry.getValue(), null);
       }
     }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
@@ -185,8 +185,9 @@ public class Main {
     private void startNMInstances(Injector injector) {
       Map<String, Integer> nmInstances = injector.getInstance(MyriadConfiguration.class).getNmInstances();
       MyriadOperations myriadOperations = injector.getInstance(MyriadOperations.class);
+      NMProfileManager profileManager = injector.getInstance(NMProfileManager.class);
       for (Map.Entry<String, Integer> entry : nmInstances.entrySet()) {
-        myriadOperations.flexUpCluster(entry.getValue(), entry.getKey());
+        myriadOperations.flexUpCluster(profileManager.get(entry.getKey()), entry.getValue());
       }
     }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.ebay.myriad.api.model.FlexDownClusterRequest;
 import com.ebay.myriad.api.model.FlexUpClusterRequest;
 import com.ebay.myriad.scheduler.MyriadOperations;
+import com.ebay.myriad.scheduler.NMProfile;
 import com.ebay.myriad.scheduler.NMProfileManager;
 import com.ebay.myriad.scheduler.constraints.ConstraintFactory;
 import com.ebay.myriad.state.SchedulerState;
@@ -108,11 +109,11 @@ public class ClustersResource {
         isValidRequest = isValidRequest && validateInstances(instances, response);
         isValidRequest = isValidRequest && validateConstraints(constraints, response);
 
-        Integer numFlexedUp = this.getNumFlexedupNMs();
+        Integer numFlexedUp = this.getNumFlexedupNMs(profile);
         if (isValidRequest && numFlexedUp < instances)  {
             String message = String.format("Number of requested instances for flexdown is greater than the number of " +
-                "Node Managers previously flexed up. Requested: %d, Previously flexed Up: %d. " +
-                "Only %d Node Managers will be flexed down", instances, numFlexedUp, numFlexedUp);
+                "Node Managers previously flexed up for profile '%s'. Requested: %d, Previously flexed Up: %d. " +
+                "Only %d Node Managers will be flexed down.", profile, instances, numFlexedUp, numFlexedUp);
             response.entity(message);
             LOGGER.warn(message);
         }
@@ -203,10 +204,11 @@ public class ClustersResource {
     }
 
 
-    private Integer getNumFlexedupNMs() {
-        return this.schedulerState.getActiveTaskIds().size()
-                + this.schedulerState.getStagingTaskIds().size()
-                + this.schedulerState.getPendingTaskIds().size();
+    private Integer getNumFlexedupNMs(String profile) {
+      NMProfile nmProfile = profileManager.get(profile);
+      return this.schedulerState.getActiveTaskIDsForProfile(nmProfile).size()
+                + this.schedulerState.getStagingTaskIDsForProfile(nmProfile).size()
+                + this.schedulerState.getPendingTaskIDsForProfile(nmProfile).size();
     }
 
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @Path("/cluster")
 public class ClustersResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClustersResource.class);
-    private static final String CONSTRAINT_FORMAT =
+    private static final String LIKE_CONSTRAINT_FORMAT =
         "'<mesos_slave_attribute|hostname> LIKE <value_regex>'";
 
     private final SchedulerState schedulerState;
@@ -176,7 +176,8 @@ public class ClustersResource {
 
     private boolean validateLIKEConstraint(String constraint, ResponseBuilder response) {
       if (constraint.isEmpty()) {
-        String message = String.format("The value provided for 'constraints' is empty. Format: %s", CONSTRAINT_FORMAT);
+        String message = String.format("The value provided for 'constraints' is empty. Format: %s",
+          LIKE_CONSTRAINT_FORMAT);
         response.status(Status.BAD_REQUEST).entity(message);
         LOGGER.error(message);
         return false;
@@ -185,7 +186,7 @@ public class ClustersResource {
       String[] splits = constraint.split(" LIKE "); // "<key> LIKE <val_regex>"
       if (splits.length != 2) {
         String message = String.format("Invalid format for LIKE operator in constraint: %s. Format: %s",
-            constraint, CONSTRAINT_FORMAT);
+            constraint, LIKE_CONSTRAINT_FORMAT);
         response.status(Status.BAD_REQUEST).entity(message);
         LOGGER.error(message);
         return false;

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownClusterRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownClusterRequest.java
@@ -24,13 +24,17 @@ import org.hibernate.validator.constraints.NotEmpty;
 public class FlexDownClusterRequest {
 
     @NotEmpty
+    public String profile;
+
+    @NotEmpty
     public Integer instances;
 
     public FlexDownClusterRequest() {
     }
 
-    public FlexDownClusterRequest(Integer instances) {
+    public FlexDownClusterRequest(String profile, Integer instances) {
         this.instances = instances;
+        this.profile = profile;
     }
 
     public Integer getInstances() {
@@ -39,6 +43,14 @@ public class FlexDownClusterRequest {
 
     public void setInstances(Integer instances) {
         this.instances = instances;
+    }
+
+    public String getProfile() {
+      return profile;
+    }
+
+    public void setProfile(String profile) {
+      this.profile = profile;
     }
 
     public String toString() {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownClusterRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownClusterRequest.java
@@ -16,6 +16,7 @@
 package com.ebay.myriad.api.model;
 
 import com.google.gson.Gson;
+import java.util.List;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
@@ -29,12 +30,15 @@ public class FlexDownClusterRequest {
     @NotEmpty
     public Integer instances;
 
+    public List<String> constraints;
+
     public FlexDownClusterRequest() {
     }
 
-    public FlexDownClusterRequest(String profile, Integer instances) {
+    public FlexDownClusterRequest(String profile, Integer instances, List<String> constraints) {
         this.instances = instances;
         this.profile = profile;
+        this.constraints = constraints;
     }
 
     public Integer getInstances() {
@@ -51,6 +55,14 @@ public class FlexDownClusterRequest {
 
     public void setProfile(String profile) {
       this.profile = profile;
+    }
+
+    public List<String> getConstraints() {
+      return constraints;
+    }
+
+    public void setConstraints(List<String> constraints) {
+      this.constraints = constraints;
     }
 
     public String toString() {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpClusterRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpClusterRequest.java
@@ -16,6 +16,7 @@
 package com.ebay.myriad.api.model;
 
 import com.google.gson.Gson;
+import java.util.List;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
@@ -28,12 +29,15 @@ public class FlexUpClusterRequest {
     @NotEmpty
     public String profile;
 
+    public List<String> constraints;
+
     public FlexUpClusterRequest() {
     }
     
-    public FlexUpClusterRequest(Integer instances, String profile) {
+    public FlexUpClusterRequest(Integer instances, String profile, List<String> constraints) {
         this.instances = instances;
         this.profile = profile;
+        this.constraints = constraints;
     }
 
     public Integer getInstances() {
@@ -50,6 +54,14 @@ public class FlexUpClusterRequest {
 
     public void setProfile(String profile) {
         this.profile = profile;
+    }
+
+    public List<String> getConstraints() {
+      return constraints;
+    }
+
+    public void setConstraints(List<String> constraints) {
+      this.constraints = constraints;
     }
 
     public String toString() {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/policy/LeastAMNodesFirstPolicy.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/policy/LeastAMNodesFirstPolicy.java
@@ -2,7 +2,7 @@ package com.ebay.myriad.policy;
 
 import com.ebay.myriad.scheduler.yarn.interceptor.BaseInterceptor;
 import com.ebay.myriad.scheduler.yarn.interceptor.InterceptorRegistry;
-import com.google.common.collect.Lists;
+import com.ebay.myriad.state.SchedulerState;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
@@ -10,11 +10,11 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeRemovedSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeUpdateSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEvent;
+import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -28,6 +28,7 @@ public class LeastAMNodesFirstPolicy extends BaseInterceptor implements NodeScal
     private static final Logger LOGGER = LoggerFactory.getLogger(LeastAMNodesFirstPolicy.class);
 
     private final AbstractYarnScheduler yarnScheduler;
+    private final SchedulerState schedulerState;
 
     //TODO(Santosh): Should figure out the right values for the hashmap properties.
     // currently it's tuned for 200 nodes and 50 RM RPC threads (Yarn's default).
@@ -35,20 +36,26 @@ public class LeastAMNodesFirstPolicy extends BaseInterceptor implements NodeScal
     private static final int EXPECTED_CONCURRENT_ACCCESS_COUNT = 50;
     private static final float LOAD_FACTOR_DEFAULT = 0.75f;
 
-    private Map<String, SchedulerNode> schedulerNodes = new ConcurrentHashMap<>(INITIAL_NODE_SIZE, LOAD_FACTOR_DEFAULT, EXPECTED_CONCURRENT_ACCCESS_COUNT);
+    private Map<String, SchedulerNode> schedulerNodes =
+        new ConcurrentHashMap<>(INITIAL_NODE_SIZE, LOAD_FACTOR_DEFAULT, EXPECTED_CONCURRENT_ACCCESS_COUNT);
 
     @Inject
-    public LeastAMNodesFirstPolicy(InterceptorRegistry registry, AbstractYarnScheduler yarnScheduler) {
+    public LeastAMNodesFirstPolicy(InterceptorRegistry registry,
+                                   AbstractYarnScheduler yarnScheduler,
+                                   SchedulerState schedulerState) {
         registry.register(this);
         this.yarnScheduler = yarnScheduler;
+        this.schedulerState = schedulerState;
     }
 
+    /**
+     *  Sort the given list of tasks by the number of App Master containers running on the corresponding NM node.
+     * @param taskIDs
+     */
     @Override
-    public List<String> getNodesToScaleDown() {
-        List<SchedulerNode> nodes = Lists.newArrayList(this.schedulerNodes.values());
-
+    public void apply(List<Protos.TaskID> taskIDs) {
         if (LOGGER.isDebugEnabled()) {
-            for (SchedulerNode node : nodes) {
+            for (SchedulerNode node : schedulerNodes.values()) {
                 LOGGER.debug("Host {} is running {} containers including {} App Masters",
                         node.getNodeID().getHost(), node.getRunningContainers().size(),
                         getNumAMContainers(node.getRunningContainers()));
@@ -58,9 +65,22 @@ public class LeastAMNodesFirstPolicy extends BaseInterceptor implements NodeScal
         // process HBs from NodeManagers and the state of SchedulerNode objects might change while we
         // are in the middle of sorting them based on the least number of AM containers.
         synchronized (yarnScheduler) {
-            Collections.sort(nodes, new Comparator<SchedulerNode>() {
+            Collections.sort(taskIDs, new Comparator<Protos.TaskID>() {
                 @Override
-                public int compare(SchedulerNode o1, SchedulerNode o2) {
+                public int compare(Protos.TaskID t1, Protos.TaskID t2) {
+                    SchedulerNode o1 = schedulerNodes.get(schedulerState.getTask(t1).getHostname());
+                    SchedulerNode o2 = schedulerNodes.get(schedulerState.getTask(t2).getHostname());
+
+                    if (o1 == null) { // a NM was launched by Myriad, but it hasn't yet registered with RM
+                      if (o2 == null) {
+                        return 0;
+                      } else {
+                        return -1;
+                      }
+                    } else if (o2 == null) {
+                      return 1;
+                    } // else, both the NMs have registered with RM
+
                     List<RMContainer> runningContainers1 = o1.getRunningContainers();
                     List<RMContainer> runningContainers2 = o2.getRunningContainers();
 
@@ -78,13 +98,6 @@ public class LeastAMNodesFirstPolicy extends BaseInterceptor implements NodeScal
                 }
             });
         }
-
-        List<String> hosts = new ArrayList<>(nodes.size());
-        for (SchedulerNode node : nodes) {
-            hosts.add(node.getNodeID().getHost());
-        }
-
-        return hosts;
     }
 
     @Override

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/policy/NodeScaleDownPolicy.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/policy/NodeScaleDownPolicy.java
@@ -1,5 +1,7 @@
 package com.ebay.myriad.policy;
 
+import org.apache.mesos.Protos;
+
 import java.util.List;
 
 /**
@@ -8,11 +10,9 @@ import java.util.List;
 public interface NodeScaleDownPolicy {
 
     /**
-     * Get a list of host names of the nodes that needs to be scaled down.
-     * The implementation of the policy should populate this list in a way that
-     * the most preferred nodes to be scaled down should occur first in the list.
-     * @return
+     * Apply a scale down policy to the given list of taskIDs.
+     * @param taskIDs
      */
-    public List<String> getNodesToScaleDown();
+    public void apply(List<Protos.TaskID> taskIDs);
 
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
@@ -62,7 +62,7 @@ public class MyriadOperations {
 
           for (Protos.TaskID taskId : pendingTasks) {
             NodeTask nodeTask = schedulerState.getTask(taskId);
-            if (nodeTask.getProfile().getName().equals(profile.getName()) &&
+            if (nodeTask != null && nodeTask.getProfile().getName().equals(profile.getName()) &&
                 meetsConstraint(nodeTask, constraint)) {
               this.schedulerState.makeTaskKillable(taskId);
               numPendingTasksScaledDown++;
@@ -79,7 +79,7 @@ public class MyriadOperations {
 
           for (Protos.TaskID taskId : stagingTasks) {
             NodeTask nodeTask = schedulerState.getTask(taskId);
-            if (nodeTask.getProfile().getName().equals(profile.getName()) &&
+            if (nodeTask != null && nodeTask.getProfile().getName().equals(profile.getName()) &&
                 meetsConstraint(nodeTask, constraint)) {
               this.schedulerState.makeTaskKillable(taskId);
               numStagingTasksScaledDown++;
@@ -134,6 +134,9 @@ public class MyriadOperations {
           } else {
             return likeConstraint.matchesSlaveAttributes(nodeTask.getSlaveAttributes());
           }
+
+        default:
+          return false;
       }
     }
     return true;

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
@@ -20,16 +20,15 @@ import com.ebay.myriad.scheduler.constraints.Constraint;
 import com.ebay.myriad.scheduler.constraints.LikeConstraint;
 import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * Myriad scheduler operations
@@ -57,68 +56,61 @@ public class MyriadOperations {
 
     public void flexDownCluster(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
         // Flex down Pending tasks, if any
-        int numPendingTasksScaledDown = 0;
-          Set<Protos.TaskID> pendingTasks = Sets.newHashSet(this.schedulerState.getPendingTaskIds());
-
-          for (Protos.TaskID taskId : pendingTasks) {
-            NodeTask nodeTask = schedulerState.getTask(taskId);
-            if (nodeTask != null && nodeTask.getProfile().getName().equals(profile.getName()) &&
-                meetsConstraint(nodeTask, constraint)) {
-              this.schedulerState.makeTaskKillable(taskId);
-              numPendingTasksScaledDown++;
-              if (numPendingTasksScaledDown == numInstancesToScaleDown) {
-                break;
-              }
-            }
-          }
+        int numPendingTasksScaledDown = flexDownPendingTasks(
+            profile, constraint, numInstancesToScaleDown);
 
         // Flex down Staging tasks, if any
-        int numStagingTasksScaledDown = 0;
-        if (numPendingTasksScaledDown < numInstancesToScaleDown) {
-          Set<Protos.TaskID> stagingTasks = Sets.newHashSet(this.schedulerState.getStagingTaskIds());
+        int numStagingTasksScaledDown = flexDownStagingTasks(
+            profile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown);
 
-          for (Protos.TaskID taskId : stagingTasks) {
-            NodeTask nodeTask = schedulerState.getTask(taskId);
-            if (nodeTask != null && nodeTask.getProfile().getName().equals(profile.getName()) &&
-                meetsConstraint(nodeTask, constraint)) {
-              this.schedulerState.makeTaskKillable(taskId);
-              numStagingTasksScaledDown++;
-              if (numStagingTasksScaledDown + numPendingTasksScaledDown == numInstancesToScaleDown) {
-                break;
-              }
-            }
-          }
-        }
-
-        int numActiveTasksScaledDown = 0;
-        if (numPendingTasksScaledDown + numStagingTasksScaledDown < numInstancesToScaleDown) {
-          Set<NodeTask> activeTasksForProfile = Sets.newHashSet(this.schedulerState.getActiveTasksForProfile(profile));
-          List<String> nodesToScaleDown = nodeScaleDownPolicy.getNodesToScaleDown();
-          filterUnregisteredNMs(activeTasksForProfile, nodesToScaleDown);
-
-          for (int i = 0; i < numInstancesToScaleDown - (numPendingTasksScaledDown + numStagingTasksScaledDown); i++) {
-            for (NodeTask nodeTask : activeTasksForProfile) {
-              if (nodesToScaleDown.size() > i &&
-                  nodesToScaleDown.get(i).equals(nodeTask.getHostname()) &&
-                  meetsConstraint(nodeTask, constraint)) {
-                this.schedulerState.makeTaskKillable(nodeTask.getTaskStatus().getTaskId());
-                numActiveTasksScaledDown++;
-                if (LOGGER.isDebugEnabled()) {
-                  LOGGER.debug("Marked NodeTask {} on host {} for kill.",
-                      nodeTask.getTaskStatus().getTaskId(), nodeTask.getHostname());
-                }
-              }
-            }
-          }
-        }
+        // Flex down Active tasks, if any
+        int numActiveTasksScaledDown = flexDownActiveTasks(
+            profile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown - numStagingTasksScaledDown);
 
         if (numActiveTasksScaledDown + numStagingTasksScaledDown + numPendingTasksScaledDown == 0) {
-          LOGGER.info("No Node Managers with profile '{}' and constraint {} found for scaling down.",
-              profile.getName(), constraint.toString());
+          LOGGER.info("No Node Managers with profile '{}' and constraint '{}' found for scaling down.",
+              profile.getName(), constraint == null ? "null" : constraint.toString());
         } else {
-          LOGGER.info("Flexed down {} active, {} staging  and {} pending Node Managers with '{}' profile.",
-              numActiveTasksScaledDown, numStagingTasksScaledDown, numPendingTasksScaledDown, profile.getName());
+          LOGGER.info("Flexed down {} active, {} staging  and {} pending Node Managers with " +
+              "'{}' profile and constraint '{}'.", numActiveTasksScaledDown, numStagingTasksScaledDown,
+              numPendingTasksScaledDown, profile.getName(), constraint == null ? "null" : constraint.toString());
         }
+    }
+
+    private int flexDownPendingTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+      return numInstancesToScaleDown > 0 ? flexDownTasks(schedulerState.getPendingTaskIDsForProfile(profile),
+          profile, constraint, numInstancesToScaleDown) : 0;
+    }
+
+  private int flexDownStagingTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+      return numInstancesToScaleDown > 0 ? flexDownTasks(schedulerState.getStagingTaskIDsForProfile(profile),
+          profile, constraint, numInstancesToScaleDown) : 0;
+    }
+
+    private int flexDownActiveTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+      if (numInstancesToScaleDown > 0) {
+        List<Protos.TaskID> activeTasksForProfile = Lists.newArrayList(schedulerState.getActiveTaskIDsForProfile(profile));
+        nodeScaleDownPolicy.apply(activeTasksForProfile);
+        return flexDownTasks(activeTasksForProfile, profile, constraint, numInstancesToScaleDown);
+      }
+      return 0;
+    }
+
+  private int flexDownTasks(Collection<Protos.TaskID> taskIDs, NMProfile profile,
+                              Constraint constraint, int numInstancesToScaleDown) {
+      int numInstancesScaledDown = 0;
+      for (Protos.TaskID taskID : taskIDs) {
+        NodeTask nodeTask = schedulerState.getTask(taskID);
+        if (nodeTask.getProfile().getName().equals(profile.getName()) &&
+            meetsConstraint(nodeTask, constraint)) {
+          this.schedulerState.makeTaskKillable(taskID);
+          numInstancesScaledDown++;
+          if (numInstancesScaledDown == numInstancesToScaleDown) {
+            break;
+          }
+        }
+      }
+      return numInstancesScaledDown;
     }
 
   private boolean meetsConstraint(NodeTask nodeTask, Constraint constraint) {
@@ -142,22 +134,4 @@ public class MyriadOperations {
     return true;
   }
 
-  private void filterUnregisteredNMs(Set<NodeTask> activeTasksForProfile, List<String> registeredNMHosts) {
-    // If a NM is flexed down it takes time for the RM to realize the NM is no longer up
-    // We need to make sure we filter out nodes that have already been flexed down
-    // but have not disappeared from the RM's view of the cluster
-    for (Iterator<String> iterator = registeredNMHosts.iterator(); iterator.hasNext();) {
-        String nodeToScaleDown = iterator.next();
-        boolean nodePresentInMyriad = false;
-        for (NodeTask nodeTask : activeTasksForProfile) {
-            if (nodeTask.getHostname().equals(nodeToScaleDown)) {
-                nodePresentInMyriad = true;
-                break;
-            }
-        }
-        if (!nodePresentInMyriad) {
-            iterator.remove();
-        }
-    }
-  }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Rebalancer.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Rebalancer.java
@@ -44,7 +44,7 @@ public class Rebalancer implements Runnable {
     public void run() {
         LOGGER.info("Active {}, Pending {}", schedulerState.getActiveTaskIds().size(), schedulerState.getPendingTaskIds().size());
         if (schedulerState.getActiveTaskIds().size() < 1 && schedulerState.getPendingTaskIds().size() < 1) {
-            myriadOperations.flexUpCluster(profileManager.get("small"), 1);
+            myriadOperations.flexUpCluster(profileManager.get("small"), 1, null);
         }
 //            RestAdapter restAdapter = new RestAdapter.Builder()
 //                    .setEndpoint("http://" + host + ":" + port)

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/SchedulerUtils.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/SchedulerUtils.java
@@ -19,41 +19,17 @@ import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.base.Preconditions;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.Attribute;
-import org.apache.mesos.Protos.Offer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Provides utilities for scheduling with the mesos offers
  */
 public class SchedulerUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerUtils.class);
-
-    public static boolean isMatchSlaveAttributes(Offer offer, Map<String, String> requestAttributes) {
-        boolean match = true;
-
-        Map<String, String> offerAttributes = new HashMap<>();
-        for (Attribute attribute : offer.getAttributesList()) {
-            offerAttributes.put(attribute.getName(), attribute.getText().getValue());
-        }
-
-        // Match with offer attributes only if request has attributes.
-        if (!MapUtils.isEmpty(requestAttributes)) {
-            match = offerAttributes.equals(requestAttributes);
-        }
-
-        LOGGER.debug("Match status: {} for offer: {} and requestAttributes: {}",
-                match, offer, requestAttributes);
-
-        return match;
-    }
 
     public static boolean isUniqueHostname(Protos.OfferOrBuilder offer,
                                            Collection<NodeTask> tasks) {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskTerminator.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskTerminator.java
@@ -15,18 +15,16 @@
  */
 package com.ebay.myriad.scheduler;
 
-import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import java.util.Set;
+import javax.inject.Inject;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos.Status;
 import org.apache.mesos.Protos.TaskID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import java.util.Set;
 
 /**
  * {@link TaskTerminator} is responsible for killing tasks.
@@ -34,14 +32,11 @@ import java.util.Set;
 public class TaskTerminator implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(MyriadDriverManager.class);
 
-    private MyriadConfiguration cfg;
     private SchedulerState schedulerState;
     private MyriadDriverManager driverManager;
 
     @Inject
-    public TaskTerminator(MyriadConfiguration cfg,
-                          SchedulerState schedulerState, MyriadDriverManager driverManager) {
-        this.cfg = cfg;
+    public TaskTerminator(SchedulerState schedulerState, MyriadDriverManager driverManager) {
         this.schedulerState = schedulerState;
         this.driverManager = driverManager;
     }
@@ -64,9 +59,13 @@ public class TaskTerminator implements Runnable {
         }
 
         for (TaskID taskIdToKill : killableTasks) {
-            Status status = this.driverManager.kill(taskIdToKill);
-            this.schedulerState.removeTask(taskIdToKill);
-            Preconditions.checkState(status == Status.DRIVER_RUNNING);
+            if (this.schedulerState.getPendingTaskIds().contains(taskIdToKill)) {
+              this.schedulerState.removeTask(taskIdToKill);
+            } else {
+              Status status = this.driverManager.kill(taskIdToKill);
+              this.schedulerState.removeTask(taskIdToKill);
+              Preconditions.checkState(status == Status.DRIVER_RUNNING);
+            }
         }
     }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/Constraint.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/Constraint.java
@@ -1,0 +1,17 @@
+package com.ebay.myriad.scheduler.constraints;
+
+/**
+ * Interface for Constraint.
+ */
+public interface Constraint {
+  /**
+   * Type of Constraint
+   */
+  enum Type {
+    NULL, // to help with serialization
+    LIKE
+  }
+
+  public Type getType();
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/ConstraintFactory.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/ConstraintFactory.java
@@ -1,0 +1,18 @@
+package com.ebay.myriad.scheduler.constraints;
+
+/**
+ * Factory to create constraints.
+ */
+public class ConstraintFactory {
+
+  public static Constraint createConstraint(String constraintStr) {
+    if (constraintStr != null) {
+      String[] splits = constraintStr.split(" LIKE ");
+      if (splits.length == 2) {
+        return new LikeConstraint(splits[0], splits[1]);
+      }
+    }
+    return null;
+  }
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/LikeConstraint.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/LikeConstraint.java
@@ -80,7 +80,7 @@ public class LikeConstraint implements Constraint {
     if (lhs != null ? !lhs.equals(that.lhs) : that.lhs != null) {
       return false;
     }
-    if (pattern != null ? !pattern.equals(that.pattern) : that.pattern != null) {
+    if (pattern != null ? !pattern.pattern().equals(that.pattern.pattern()) : that.pattern != null) {
       return false;
     }
 
@@ -90,7 +90,7 @@ public class LikeConstraint implements Constraint {
   @Override
   public int hashCode() {
     int result = lhs != null ? lhs.hashCode() : 0;
-    result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
+    result = 31 * result + (pattern != null ? pattern.pattern().hashCode() : 0);
     return result;
   }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/LikeConstraint.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/constraints/LikeConstraint.java
@@ -1,0 +1,94 @@
+package com.ebay.myriad.scheduler.constraints;
+
+import com.google.gson.Gson;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import org.apache.mesos.Protos.Attribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Constraint for LIKE operator.
+ * Format: <mesos_slave_attribute|hostname> LIKE <regex_value>
+ */
+public class LikeConstraint implements Constraint {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LikeConstraint.class);
+
+  private String lhs;
+  private String rhsRegex;
+
+  public LikeConstraint(String lhs, String rhsRegex) {
+    this.lhs = lhs;
+    this.rhsRegex = rhsRegex;
+  }
+
+  public boolean isConstraintOnHostName() {
+    return lhs.equalsIgnoreCase("hostname");
+  }
+
+  public boolean matchesHostName(String hostname) {
+    return lhs.equalsIgnoreCase("hostname") && hostname != null && Pattern.matches(rhsRegex, hostname);
+  }
+
+  public boolean matchesSlaveAttributes(Collection<Attribute> attributes) {
+    if (!lhs.equalsIgnoreCase("hostname") && attributes != null) {
+      for (Attribute attr : attributes) {
+        if (attr.getName().equalsIgnoreCase(lhs)) {
+          switch (attr.getType()) {
+            case TEXT:
+              return Pattern.matches(rhsRegex, attr.getText().getValue());
+
+            case SCALAR:
+              return Pattern.matches(rhsRegex, String.valueOf(attr.getScalar().getValue()));
+
+            default:
+              LOGGER.warn("LIKE constraint currently doesn't support Mesos slave attributes " +
+                  "of type {}. Attribute Name: {}", attr.getType(), attr.getName());
+              return false;
+
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.LIKE;
+  }
+
+  @Override
+  public String toString() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LikeConstraint)) {
+      return false;
+    }
+
+    LikeConstraint that = (LikeConstraint) o;
+
+    if (lhs != null ? !lhs.equals(that.lhs) : that.lhs != null) {
+      return false;
+    }
+    if (rhsRegex != null ? !rhsRegex.equals(that.rhsRegex) : that.rhsRegex != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = lhs != null ? lhs.hashCode() : 0;
+    result = 31 * result + (rhsRegex != null ? rhsRegex.hashCode() : 0);
+    return result;
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -20,6 +20,8 @@ import com.ebay.myriad.scheduler.NMProfile;
 import com.ebay.myriad.scheduler.SchedulerUtils;
 import com.ebay.myriad.scheduler.TaskFactory;
 import com.ebay.myriad.scheduler.TaskUtils;
+import com.ebay.myriad.scheduler.constraints.Constraint;
+import com.ebay.myriad.scheduler.constraints.LikeConstraint;
 import com.ebay.myriad.scheduler.event.ResourceOffersEvent;
 import com.ebay.myriad.scheduler.fgs.OfferLifecycleManager;
 import com.ebay.myriad.state.NodeTask;
@@ -78,7 +80,10 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     // a notification for "framework registration". This is a simple defensive code
     // to not process any offers unless Myriad receives a "framework registered" notification.
     if (schedulerState.getFrameworkID() == null) {
-      LOGGER.warn("Received {} offers, but not processing them since Framework ID is not yet set", offers.size());
+      LOGGER.warn("Received {} offers, but declining them since Framework ID is not yet set", offers.size());
+      for (Offer offer : offers) {
+        driver.declineOffer(offer.getId());
+      }
       return;
     }
     LOGGER.info("Received offers {}", offers.size());
@@ -87,14 +92,19 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     try {
       for (Iterator<Offer> iterator = offers.iterator(); iterator.hasNext();) {
         Offer offer = iterator.next();
+        NodeTask nodeTask = schedulerState.getNodeTask(offer.getSlaveId());
+        if (nodeTask != null) {
+          nodeTask.setSlaveAttributes(offer.getAttributesList());
+        }
         Set<Protos.TaskID> pendingTasks = schedulerState.getPendingTaskIds();
         if (CollectionUtils.isNotEmpty(pendingTasks)) {
           for (Protos.TaskID pendingTaskId : pendingTasks) {
             NodeTask taskToLaunch = schedulerState
                 .getTask(pendingTaskId);
             NMProfile profile = taskToLaunch.getProfile();
+            Constraint constraint = taskToLaunch.getConstraint();
 
-            if (matches(offer, profile)
+            if (matches(offer, profile, constraint)
                 && SchedulerUtils.isUniqueHostname(offer,
                 schedulerState.getActiveTasks())) {
               TaskInfo task = taskFactory.createTask(offer, schedulerState.getFrameworkID(), pendingTaskId,
@@ -143,7 +153,12 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     }
   }
 
-  private boolean matches(Offer offer, NMProfile profile) {
+  private boolean matches(Offer offer, NMProfile profile, Constraint constraint) {
+
+    if (!meetsConstraint(offer, constraint)) {
+      return false;
+    }
+
     Map<String, Object> results = new HashMap<String, Object>(5);
 
     for (Resource resource : offer.getResourcesList()) {
@@ -163,6 +178,23 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     checkResource(ports < 0, "port");
 
     return checkAggregates(offer, profile, ports, cpus, mem);
+  }
+
+  private boolean meetsConstraint(Offer offer, Constraint constraint) {
+    if (constraint != null) {
+      switch (constraint.getType()) {
+        case LIKE:
+        {
+          LikeConstraint likeConstraint = (LikeConstraint) constraint;
+          if (likeConstraint.isConstraintOnHostName()) {
+            return likeConstraint.matchesHostName(offer.getHostname());
+          } else {
+            return likeConstraint.matchesSlaveAttributes(offer.getAttributesList());
+          }
+        }
+      }
+    }
+    return true;
   }
 
   private void checkResource(boolean fail, String resource) {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -177,7 +177,7 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     checkResource(mem < 0, "mem");
     checkResource(ports < 0, "port");
 
-    return checkAggregates(offer, profile, ports, cpus, mem);
+    return checkAggregates(profile, ports, cpus, mem);
   }
 
   private boolean meetsConstraint(Offer offer, Constraint constraint) {
@@ -203,17 +203,16 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     }
   }
 
-  private boolean checkAggregates(Offer offer, NMProfile profile, int ports, double cpus, double mem) {
-    Map<String, String> requestAttributes = new HashMap<>();
+  private boolean checkAggregates(NMProfile profile, int ports, double cpus, double mem) {
 
     if (taskUtils.getAggregateCpus(profile) <= cpus
         && taskUtils.getAggregateMemory(profile) <= mem
-        && SchedulerUtils.isMatchSlaveAttributes(offer, requestAttributes)
         && NMPorts.expectedNumPorts() <= ports) {
       return true;
     } else {
-      LOGGER.info("Offer not sufficient for task with, cpu: {}, memory: {}, ports: {}",
-          taskUtils.getAggregateCpus(profile), taskUtils.getAggregateMemory(profile), ports);
+      LOGGER.info("Offer not sufficient for launching task. Task requires cpu: {}, memory: {}, # of ports: {}. " +
+          "Offer has cpu: {}, memory: {}, # of ports: {}", taskUtils.getAggregateCpus(profile),
+          taskUtils.getAggregateMemory(profile), NMPorts.expectedNumPorts(), cpus, mem, ports);
       return false;
     }
   }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -74,6 +74,13 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     SchedulerDriver driver = event.getDriver();
     List<Offer> offers = event.getOffers();
 
+    // Sometimes, we see that mesos sends resource offers before Myriad receives
+    // a notification for "framework registration". This is a simple defensive code
+    // to not process any offers unless Myriad receives a "framework registered" notification.
+    if (schedulerState.getFrameworkID() == null) {
+      LOGGER.warn("Received {} offers, but not processing them since Framework ID is not yet set", offers.size());
+      return;
+    }
     LOGGER.info("Received offers {}", offers.size());
     LOGGER.debug("Pending tasks: {}", this.schedulerState.getPendingTaskIds());
     driverOperationLock.lock();

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/NodeTask.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/NodeTask.java
@@ -16,8 +16,11 @@
 package com.ebay.myriad.state;
 
 import com.ebay.myriad.scheduler.NMProfile;
+import com.ebay.myriad.scheduler.constraints.Constraint;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Attribute;
 
 /**
  * Represents a task to be launched by the executor
@@ -37,9 +40,13 @@ public class NodeTask {
      */
     private Protos.ExecutorInfo executorInfo;
 
-    public NodeTask(NMProfile profile) {
+    private Constraint constraint;
+    private List<Attribute> slaveAttributes;
+
+    public NodeTask(NMProfile profile, Constraint constraint) {
         this.profile = profile;
         this.hostname = "";
+        this.constraint = constraint;
     }
 
     public Protos.SlaveID getSlaveId() {
@@ -56,6 +63,10 @@ public class NodeTask {
 
     public void setProfile(NMProfile profile) {
         this.profile = profile;
+    }
+
+    public Constraint getConstraint() {
+      return constraint;
     }
 
     public String getHostname() {
@@ -80,5 +91,13 @@ public class NodeTask {
 
     public void setExecutorInfo(Protos.ExecutorInfo executorInfo) {
         this.executorInfo = executorInfo;
+    }
+
+    public void setSlaveAttributes(List<Attribute> slaveAttributes) {
+      this.slaveAttributes = slaveAttributes;
+    }
+
+    public List<Attribute> getSlaveAttributes() {
+      return slaveAttributes;
     }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
@@ -16,26 +16,15 @@
 package com.ebay.myriad.state;
 
 import com.ebay.myriad.scheduler.NMProfile;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.ebay.myriad.state.utils.StoreContext;
 import org.apache.commons.collections.CollectionUtils;
-
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.SlaveID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.SlaveID;
-
-import com.ebay.myriad.state.utils.StoreContext;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Represents the state of the Myriad scheduler
@@ -175,6 +164,17 @@ public class SchedulerState {
         return Collections.unmodifiableSet(this.pendingTasks);
     }
 
+    public synchronized Collection<Protos.TaskID> getPendingTaskIDsForProfile(NMProfile profile) {
+      List<Protos.TaskID> pendingTaskIds = new ArrayList<>();
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        NodeTask nodeTask = entry.getValue();
+        if (pendingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+          pendingTaskIds.add(entry.getKey());
+        }
+      }
+      return Collections.unmodifiableCollection(pendingTaskIds);
+    }
+
     public synchronized Set<Protos.TaskID> getActiveTaskIds() {
         return Collections.unmodifiableSet(this.activeTasks);
     }
@@ -192,18 +192,18 @@ public class SchedulerState {
         return Collections.unmodifiableCollection(activeNodeTasks);
     }
 
-    public synchronized Collection<NodeTask> getActiveTasksForProfile(NMProfile profile) {
-      List<NodeTask> activeNodeTasks = new ArrayList<>();
+    public synchronized Collection<Protos.TaskID> getActiveTaskIDsForProfile(NMProfile profile) {
+      List<Protos.TaskID> activeTaskIDs = new ArrayList<>();
       if (CollectionUtils.isNotEmpty(activeTasks)
           && CollectionUtils.isNotEmpty(tasks.values())) {
         for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
           NodeTask nodeTask = entry.getValue();
           if (activeTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
-            activeNodeTasks.add(nodeTask);
+            activeTaskIDs.add(entry.getKey());
           }
         }
       }
-      return Collections.unmodifiableCollection(activeNodeTasks);
+      return Collections.unmodifiableCollection(activeTaskIDs);
     }
 
   // TODO (sdaingade) Clone NodeTask
@@ -221,7 +221,18 @@ public class SchedulerState {
         return Collections.unmodifiableSet(this.stagingTasks);
     }
 
-    public synchronized Set<Protos.TaskID> getLostTaskIds() {
+    public synchronized Collection<Protos.TaskID> getStagingTaskIDsForProfile(NMProfile profile) {
+      List<Protos.TaskID> stagingTaskIDs = new ArrayList<>();
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        NodeTask nodeTask = entry.getValue();
+        if (stagingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+          stagingTaskIDs.add(entry.getKey());
+        }
+      }
+      return Collections.unmodifiableCollection(stagingTaskIDs);
+    }
+
+  public synchronized Set<Protos.TaskID> getLostTaskIds() {
         return Collections.unmodifiableSet(this.lostTasks);
     }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
@@ -15,6 +15,7 @@
  */
 package com.ebay.myriad.state;
 
+import com.ebay.myriad.scheduler.NMProfile;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -191,7 +192,21 @@ public class SchedulerState {
         return Collections.unmodifiableCollection(activeNodeTasks);
     }
 
-    // TODO (sdaingade) Clone NodeTask
+    public synchronized Collection<NodeTask> getActiveTasksForProfile(NMProfile profile) {
+      List<NodeTask> activeNodeTasks = new ArrayList<>();
+      if (CollectionUtils.isNotEmpty(activeTasks)
+          && CollectionUtils.isNotEmpty(tasks.values())) {
+        for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+          NodeTask nodeTask = entry.getValue();
+          if (activeTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+            activeNodeTasks.add(nodeTask);
+          }
+        }
+      }
+      return Collections.unmodifiableCollection(activeNodeTasks);
+    }
+
+  // TODO (sdaingade) Clone NodeTask
     public synchronized NodeTask getNodeTask(SlaveID slaveId) {
         for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
             if (entry.getValue().getSlaveId() != null &&

--- a/myriad-scheduler/src/main/resources/webapp/js/components/FlexUpComponent.js
+++ b/myriad-scheduler/src/main/resources/webapp/js/components/FlexUpComponent.js
@@ -21,7 +21,7 @@ var FlexUpModal = React.createClass({
         <Col mdOffset={3}>
           <div className="modal-body">
             Flex up <Badge>{this.props.instances}</Badge> instance(s)
-             size: <Badge>{this.props.size}</Badge> ?
+             Profile: <Badge>{this.props.profile}</Badge> ?
           </div>
         </Col>
       </Row>
@@ -30,7 +30,7 @@ var FlexUpModal = React.createClass({
           <Button bsStyle="success" onClick={
             function(){
               this.props.onRequestHide();
-              this.props.onFlexUp(this.props.instances, this.props.size);
+              this.props.onFlexUp(this.props.instances, this.props.profile);
               }.bind(this) }
           >Flex Up</Button>
         </div>
@@ -46,7 +46,7 @@ var FlexUpComponent = React.createClass({
   displayName: "FlexUpComponent",
 
   getInitialState: function () {
-    return( {selectedSize: null,
+    return( {selectedSProfile: null,
              numInstances:0});
   },
 
@@ -55,21 +55,21 @@ var FlexUpComponent = React.createClass({
     this.setState({numInstances: instances});
   },
 
-  handleSizeChange: function() {
-    var size = this.refs.size.getValue();
-    this.setState({selectedSize: size});
+  handleProfileChange: function() {
+    var profile = this.refs.profile.getValue();
+    this.setState({selectedProfile: profile});
  },
 
   componentDidMount: function() {
-    this.handleSizeChange();
+    this.handleProfileChange();
     this.handleInstanceChange();
   },
 
-  onRequestFlexUp: function(instances, size) {
-    console.log( "flexing up: " + instances + " size " + size);
+  onRequestFlexUp: function(instances, profile) {
+    console.log( "flexing up: " + instances + " Profile " + profile);
     request.put('/api/cluster/flexup')
     .set('Content-Type', 'application/json')
-    .send({ "profile": size, "instances": instances})
+    .send({ "profile": profile, "instances": instances})
     .end(function(err, res){
            if (!err) {
              console.log("flexup successful!");
@@ -100,7 +100,7 @@ var FlexUpComponent = React.createClass({
       <div className="modal-container">
         <Row>
           <Col md={6}>
-            <Input type="select" label='Profile' ref="size" onChange={this.handleSizeChange} >
+            <Input type="select" label='Profile' ref="profile" onChange={this.handleProfileChange} >
               { options }
             </Input>
           </Col>
@@ -119,7 +119,7 @@ var FlexUpComponent = React.createClass({
         <Row>
           <Col md={2} mdOffset={5} >
             <ModalTrigger modal={<FlexUpModal
-                                    size={this.state.selectedSize}
+                                    profile={this.state.selectedProfile}
                                     instances={this.state.numInstances}
                                     onFlexUp={this.onRequestFlexUp} />} >
               <Button bsStyle="primary" bsSize="large">Flex Up</Button>

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/SchedulerUtilsSpec.groovy
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/SchedulerUtilsSpec.groovy
@@ -39,7 +39,7 @@ class SchedulerUtilsSpec extends Specification {
 
 
     NodeTask createNodeTask(String hostname) {
-        def node = new NodeTask(new NMProfile("", 1, 1))
+        def node = new NodeTask(new NMProfile("", 1, 1), null)
         node.hostname = hostname
         node
     }

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/constraints/LikeConstraintSpec.groovy
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/constraints/LikeConstraintSpec.groovy
@@ -50,6 +50,18 @@ class LikeConstraintSpec extends Specification {
         getTextAttribute("random", "random value"))                | true
   }
 
+  def "equals"() {
+    given:
+    def constraint1 = new LikeConstraint("hostname", "perfnode13[3-4].perf.lab")
+    def constraint2 = new LikeConstraint("hostname", "perfnode13[3-4].perf.lab")
+    def constraint3 = new LikeConstraint("hostname", "perfnode133.perf.lab")
+
+    expect:
+    constraint1.equals(constraint2)
+    !constraint1.equals(constraint3)
+    !constraint2.equals(constraint3)
+  }
+
   private static Protos.Attribute getTextAttribute(String name, String value) {
     Protos.Attribute.newBuilder()
         .setName(name)

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/constraints/LikeConstraintSpec.groovy
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/constraints/LikeConstraintSpec.groovy
@@ -1,0 +1,63 @@
+package com.ebay.myriad.scheduler.constraints
+
+import com.google.common.collect.Lists
+import org.apache.mesos.Protos
+import spock.lang.Specification
+
+import static org.apache.mesos.Protos.Value.Text
+import static org.apache.mesos.Protos.Value.Type.TEXT
+
+/**
+ *
+ * Test for LikeConstraint
+ *
+ */
+class LikeConstraintSpec extends Specification {
+
+  def "is matching host name"() {
+    given:
+    def constraint = new LikeConstraint("hostname", "host-[0-9]*.example.com")
+
+    expect:
+    returnValue == constraint.matchesHostName(inputHostName)
+
+    where:
+    inputHostName         | returnValue
+    null                  | false
+    ""                    | false
+    "blah-blue"           | false
+    "host-12.example.com" | true
+    "host-1.example.com"  | true
+    "host-2.example.com"  | true
+  }
+
+  def "is matching dfs attribute"() {
+    given:
+    def constraint = new LikeConstraint("dfs", "true")
+
+    expect:
+    returnValue == constraint.matchesSlaveAttributes(attributes)
+
+    where:
+    attributes                                                     | returnValue
+    null                                                           | false
+    Lists.newArrayList()                                           | false
+    Lists.newArrayList(getTextAttribute("dfs", ""))                | false
+    Lists.newArrayList(getTextAttribute("dfs", "false"))           | false
+    Lists.newArrayList(getTextAttribute("Distributed FS", "true")) | false
+    Lists.newArrayList(getTextAttribute("dfs", "true"))            | true
+    Lists.newArrayList(getTextAttribute("dfs", "true"),
+        getTextAttribute("random", "random value"))                | true
+  }
+
+  private static Protos.Attribute getTextAttribute(String name, String value) {
+    Protos.Attribute.newBuilder()
+        .setName(name)
+        .setType(TEXT)
+        .setText(Text.newBuilder()
+        .setValue(value))
+        .build()
+  }
+
+
+}


### PR DESCRIPTION
- Added "profile" parameter to flexdown API
- Added "constraint" parameter to both flexup/flexdown APIs. Currently supports:
  - only 1 constraint
  - only LIKE operator
  - hostname field
  - Mesos slave attribute field
- Improved the parameter validation of both flexup/down (Continuation of work done by @klucar)
- Changed the behavior of flexdown to pick NMs in "pending", "staging" states ahead of those in "active"
- Updated the API doc.
