### PR TITLE
MYRIAD-142 Specifying address:port instead of just port causes Number…

### DIFF
--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMExecutorCLGenImpl.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMExecutorCLGenImpl.java
@@ -154,7 +154,7 @@ public class NMExecutorCLGenImpl implements ExecutorCommandLineGenerator {
     addYarnNodemanagerOpt(KEY_NM_WEBAPP_ADDRESS,
       ALL_LOCAL_IPV4ADDR + Long.valueOf(ports.getWebAppHttpPort()).toString());
     addYarnNodemanagerOpt(KEY_NM_SHUFFLE_PORT,
-      ALL_LOCAL_IPV4ADDR + Long.valueOf(ports.getShufflePort()).toString());
+      Long.valueOf(ports.getShufflePort()).toString());
   }
 
   protected void appendEnvForNM(StringBuilder cmdLine) {


### PR DESCRIPTION
…FormatException if myriad.mapreduce.shuffle.port provided in any config file
