### PR TITLE
Myriad-Issue-60 Added ability to launch JHS and other services that f…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 allprojects {
     apply plugin: 'idea'
+    apply plugin: 'eclipse'
 }
 
 idea {

--- a/myriad-scheduler/build.gradle
+++ b/myriad-scheduler/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.5.1"
     compile "org.apache.curator:curator-framework:2.7.1"
     compile "org.apache.commons:commons-lang3:3.4"
+    compile 'com.google.inject.extensions:guice-multibindings:3.0'
     testCompile "org.apache.hadoop:hadoop-yarn-server-resourcemanager:${hadoopVer}:tests"
 }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/Main.java
@@ -18,16 +18,25 @@ package com.ebay.myriad;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
+import com.ebay.myriad.configuration.ServiceConfiguration;
+import com.ebay.myriad.configuration.MyriadBadConfigurationException;
 import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.health.MesosDriverHealthCheck;
 import com.ebay.myriad.health.MesosMasterHealthCheck;
 import com.ebay.myriad.health.ZookeeperHealthCheck;
+import com.ebay.myriad.scheduler.ExtendedResourceProfile;
 import com.ebay.myriad.scheduler.MyriadDriverManager;
 import com.ebay.myriad.scheduler.MyriadOperations;
 import com.ebay.myriad.scheduler.NMProfile;
-import com.ebay.myriad.scheduler.NMProfileManager;
 import com.ebay.myriad.scheduler.Rebalancer;
+import com.ebay.myriad.scheduler.ServiceProfileManager;
+import com.ebay.myriad.scheduler.ServiceResourceProfile;
+import com.ebay.myriad.scheduler.ServiceTaskConstraints;
+import com.ebay.myriad.scheduler.TaskConstraintsManager;
+import com.ebay.myriad.scheduler.TaskFactory;
 import com.ebay.myriad.scheduler.TaskTerminator;
+import com.ebay.myriad.scheduler.TaskUtils;
 import com.ebay.myriad.scheduler.yarn.interceptor.InterceptorRegistry;
 import com.ebay.myriad.webapp.MyriadWebServer;
 import com.ebay.myriad.webapp.WebAppGuiceModule;
@@ -35,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
@@ -96,13 +106,16 @@ public class Main {
         initHealthChecks(injector);
         initProfiles(injector);
         validateNMInstances(injector);
+        initServiceConfigurations(cfg, injector);
         initDisruptors(injector);
 
         initRebalancerService(cfg, injector);
         initTerminatorService(injector);
         startMesosDriver(injector);
         startNMInstances(injector);
+        startJavaBasedTaskInstance(injector);
     }
+
 
     private void startMesosDriver(Injector injector) {
         LOGGER.info("starting mesosDriver..");
@@ -138,8 +151,11 @@ public class Main {
 
     private void initProfiles(Injector injector) {
         LOGGER.info("Initializing Profiles");
-        NMProfileManager profileManager = injector.getInstance(NMProfileManager.class);
+        ServiceProfileManager profileManager = injector.getInstance(ServiceProfileManager.class);
+        TaskConstraintsManager taskConstraintsManager = injector.getInstance(TaskConstraintsManager.class);
+        taskConstraintsManager.addTaskConstraints(NodeManagerConfiguration.NM_TASK_PREFIX, new TaskFactory.NMTaskConstraints());
         Map<String, Map<String, String>> profiles = injector.getInstance(MyriadConfiguration.class).getProfiles();
+        TaskUtils taskUtils = injector.getInstance(TaskUtils.class);
         if (MapUtils.isNotEmpty(profiles)) {
             for (Map.Entry<String, Map<String, String>> profile : profiles.entrySet()) {
                 Map<String, String> profileResourceMap = profile.getValue();
@@ -149,7 +165,12 @@ public class Main {
                     Long cpu = Long.parseLong(profileResourceMap.get("cpu"));
                     Long mem = Long.parseLong(profileResourceMap.get("mem"));
 
-                    profileManager.add(new NMProfile(profile.getKey(), cpu, mem));
+                    ServiceResourceProfile serviceProfile = new ExtendedResourceProfile(new NMProfile(profile.getKey(), cpu, mem), 
+                        taskUtils.getNodeManagerCpus(), taskUtils.getNodeManagerMemory());
+                    serviceProfile.setExecutorCpu(taskUtils.getExecutorCpus());
+                    serviceProfile.setExecutorMemory(taskUtils.getExecutorMemory());
+                    
+                    profileManager.add(serviceProfile);
                 } else {
                     LOGGER.error("Invalid definition for profile: " + profile.getKey());
                 }
@@ -160,19 +181,20 @@ public class Main {
     private void validateNMInstances(Injector injector) {
         LOGGER.info("Validating nmInstances..");
         Map<String, Integer> nmInstances = injector.getInstance(MyriadConfiguration.class).getNmInstances();
-        NMProfileManager profileManager = injector.getInstance(NMProfileManager.class);
+        ServiceProfileManager profileManager = injector.getInstance(ServiceProfileManager.class);
+
         long maxCpu = Long.MIN_VALUE;
         long maxMem = Long.MIN_VALUE;
         for (Map.Entry<String, Integer> entry : nmInstances.entrySet()) {
           String profile = entry.getKey();
-          NMProfile nmProfile = profileManager.get(profile);
-          if (nmProfile == null) {
+          ServiceResourceProfile nodeManager = profileManager.get(profile);
+          if (nodeManager == null) {
             throw new RuntimeException("Invalid profile name '" + profile + "' specified in 'nmInstances'");
           }
           if (entry.getValue() > 0) {
-            if (nmProfile.getCpus() > maxCpu) { // find the profile with largest number of cpus
-              maxCpu = nmProfile.getCpus();
-              maxMem = nmProfile.getMemory(); // use the memory from the same profile
+            if (nodeManager.getCpus() > maxCpu) { // find the profile with largest number of cpus
+              maxCpu = nodeManager.getCpus().longValue();
+              maxMem = nodeManager.getMemory().longValue(); // use the memory from the same profile
             }
           }
         }
@@ -185,9 +207,34 @@ public class Main {
     private void startNMInstances(Injector injector) {
       Map<String, Integer> nmInstances = injector.getInstance(MyriadConfiguration.class).getNmInstances();
       MyriadOperations myriadOperations = injector.getInstance(MyriadOperations.class);
-      NMProfileManager profileManager = injector.getInstance(NMProfileManager.class);
+      ServiceProfileManager profileManager = injector.getInstance(ServiceProfileManager.class);
       for (Map.Entry<String, Integer> entry : nmInstances.entrySet()) {
         myriadOperations.flexUpCluster(profileManager.get(entry.getKey()), entry.getValue(), null);
+      }
+    }
+
+    /**
+     * Create ServiceProfile for any configured service
+     * @param cfg 
+     * @param injector
+     */
+    private void initServiceConfigurations(MyriadConfiguration cfg, Injector injector) {
+      LOGGER.info("Initializing initServiceConfigurations");
+      ServiceProfileManager profileManager = injector.getInstance(ServiceProfileManager.class);
+      TaskConstraintsManager taskConstraintsManager = injector.getInstance(TaskConstraintsManager.class);
+
+      Map<String, ServiceConfiguration> servicesConfigs = 
+          injector.getInstance(MyriadConfiguration.class).getServiceConfigurations();
+      if (servicesConfigs != null) {
+        for (Map.Entry<String, ServiceConfiguration> entry : servicesConfigs.entrySet()) {
+          final String taskPrefix = entry.getKey();
+          ServiceConfiguration config = entry.getValue();
+          final Double cpu = config.getCpus().or(ServiceConfiguration.DEFAULT_CPU);
+          final Double mem = config.getJvmMaxMemoryMB().or(ServiceConfiguration.DEFAULT_MEMORY);
+          
+          profileManager.add(new ServiceResourceProfile(taskPrefix, cpu, mem));
+          taskConstraintsManager.addTaskConstraints(taskPrefix, new ServiceTaskConstraints(cfg, taskPrefix));
+        }
       }
     }
 
@@ -221,4 +268,22 @@ public class Main {
         disruptorManager.init(injector);
     }
 
+    /**
+     * Start tasks for configured services 
+     * @param injector
+     */
+    private void startJavaBasedTaskInstance(Injector injector) {
+      Map<String, ServiceConfiguration> auxServicesConfigs = 
+          injector.getInstance(MyriadConfiguration.class).getServiceConfigurations();
+      if (auxServicesConfigs != null) {
+        MyriadOperations myriadOperations = injector.getInstance(MyriadOperations.class);
+        for (Map.Entry<String, ServiceConfiguration> entry : auxServicesConfigs.entrySet()) {
+          try {
+            myriadOperations.flexUpAService(entry.getValue().getMaxInstances().or(1), entry.getKey());
+          } catch (MyriadBadConfigurationException e) {
+            LOGGER.warn("Exception while trying to flexup service: {}", entry.getKey(), e);
+          }
+        } 
+      }
+    }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/MyriadModule.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/MyriadModule.java
@@ -15,20 +15,25 @@
  */
 package com.ebay.myriad;
 
+import com.ebay.myriad.configuration.ServiceConfiguration;
 import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.configuration.MyriadExecutorConfiguration;
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
 import com.ebay.myriad.policy.LeastAMNodesFirstPolicy;
 import com.ebay.myriad.policy.NodeScaleDownPolicy;
 import com.ebay.myriad.scheduler.MyriadDriverManager;
 import com.ebay.myriad.scheduler.MyriadScheduler;
 import com.ebay.myriad.scheduler.fgs.NMHeartBeatHandler;
-import com.ebay.myriad.scheduler.NMProfileManager;
 import com.ebay.myriad.scheduler.fgs.NodeStore;
 import com.ebay.myriad.scheduler.fgs.OfferLifecycleManager;
 import com.ebay.myriad.scheduler.DownloadNMExecutorCLGenImpl;
 import com.ebay.myriad.scheduler.ExecutorCommandLineGenerator;
 import com.ebay.myriad.scheduler.NMExecutorCLGenImpl;
+import com.ebay.myriad.scheduler.NMTaskFactoryAnnotation;
 import com.ebay.myriad.scheduler.ReconcileService;
+import com.ebay.myriad.scheduler.ServiceProfileManager;
+import com.ebay.myriad.scheduler.ServiceTaskFactoryImpl;
+import com.ebay.myriad.scheduler.TaskConstraintsManager;
 import com.ebay.myriad.scheduler.TaskFactory;
 import com.ebay.myriad.scheduler.TaskFactory.NMTaskFactoryImpl;
 import com.ebay.myriad.scheduler.fgs.YarnNodeCapacityManager;
@@ -40,12 +45,15 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * Guice Module for Myriad
@@ -81,16 +89,38 @@ public class MyriadModule extends AbstractModule {
         bind(InterceptorRegistry.class).toInstance(interceptorRegistry);
         bind(MyriadDriverManager.class).in(Scopes.SINGLETON);
         bind(MyriadScheduler.class).in(Scopes.SINGLETON);
-        bind(NMProfileManager.class).in(Scopes.SINGLETON);
+        bind(ServiceProfileManager.class).in(Scopes.SINGLETON);
         bind(DisruptorManager.class).in(Scopes.SINGLETON);
-        bind(TaskFactory.class).to(NMTaskFactoryImpl.class);
         bind(ReconcileService.class).in(Scopes.SINGLETON);
         bind(HttpConnectorProvider.class).in(Scopes.SINGLETON);
+        bind(TaskConstraintsManager.class).in(Scopes.SINGLETON);
+        // add special binding between TaskFactory and NMTaskFactoryImpl to ease up 
+        // usage of TaskFactory
+        bind(TaskFactory.class).annotatedWith(NMTaskFactoryAnnotation.class).to(NMTaskFactoryImpl.class);
         bind(YarnNodeCapacityManager.class).in(Scopes.SINGLETON);
         bind(NodeStore.class).in(Scopes.SINGLETON);
         bind(OfferLifecycleManager.class).in(Scopes.SINGLETON);
         bind(NMHeartBeatHandler.class).asEagerSingleton();
 
+        MapBinder<String, TaskFactory> mapBinder
+        = MapBinder.newMapBinder(binder(), String.class, TaskFactory.class);
+        mapBinder.addBinding(NodeManagerConfiguration.NM_TASK_PREFIX).to(NMTaskFactoryImpl.class).in(Scopes.SINGLETON);
+        Map<String, ServiceConfiguration> auxServicesConfigs = cfg.getServiceConfigurations();
+        if (auxServicesConfigs != null) {
+          for (Map.Entry<String, ServiceConfiguration> entry : auxServicesConfigs.entrySet()) {
+            String taskFactoryClass = entry.getValue().getTaskFactoryImplName().orNull();
+            if (taskFactoryClass != null) {
+              try {
+                Class<? extends TaskFactory> implClass = (Class<? extends TaskFactory>) Class.forName(taskFactoryClass);
+                mapBinder.addBinding(entry.getKey()).to(implClass).in(Scopes.SINGLETON);
+              } catch (ClassNotFoundException e) {
+                LOGGER.error("ClassNotFoundException", e);
+              }
+            } else {
+              mapBinder.addBinding(entry.getKey()).to(ServiceTaskFactoryImpl.class).in(Scopes.SINGLETON);
+            }
+          }
+        }
         //TODO(Santosh): Should be configurable as well
         bind(NodeScaleDownPolicy.class).to(LeastAMNodesFirstPolicy.class).in(Scopes.SINGLETON);
     }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/ClustersResource.java
@@ -17,16 +17,26 @@ package com.ebay.myriad.api;
 
 import com.codahale.metrics.annotation.Timed;
 import com.ebay.myriad.api.model.FlexDownClusterRequest;
+import com.ebay.myriad.api.model.FlexDownServiceRequest;
 import com.ebay.myriad.api.model.FlexUpClusterRequest;
 import com.ebay.myriad.scheduler.MyriadOperations;
-import com.ebay.myriad.scheduler.NMProfile;
-import com.ebay.myriad.scheduler.NMProfileManager;
+import com.ebay.myriad.scheduler.ServiceResourceProfile;
 import com.ebay.myriad.scheduler.constraints.ConstraintFactory;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.base.Preconditions;
+
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import com.ebay.myriad.api.model.FlexUpServiceRequest;
+import com.ebay.myriad.configuration.MyriadBadConfigurationException;
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.scheduler.ServiceProfileManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
@@ -36,8 +46,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * RESTful API to resource manager
@@ -48,17 +56,20 @@ public class ClustersResource {
     private static final String LIKE_CONSTRAINT_FORMAT =
         "'<mesos_slave_attribute|hostname> LIKE <value_regex>'";
 
-    private final SchedulerState schedulerState;
-    private final NMProfileManager profileManager;
-    private final MyriadOperations myriadOperations;
+    private MyriadConfiguration cfg;
+    private SchedulerState schedulerState;
+    private ServiceProfileManager profileManager;
+    private MyriadOperations myriadOperations;
 
-  @Inject
-    public ClustersResource(SchedulerState state,
-                            NMProfileManager profileManager,
+    @Inject
+    public ClustersResource(MyriadConfiguration cfg,
+                            SchedulerState state,
+                            ServiceProfileManager profileManager,
                             MyriadOperations myriadOperations) {
-        this.schedulerState = state;
-        this.profileManager = profileManager;
-        this.myriadOperations = myriadOperations;
+      this.cfg = cfg;
+      this.schedulerState = state;
+      this.profileManager = profileManager;
+      this.myriadOperations = myriadOperations;
     }
 
     @Timed
@@ -88,6 +99,46 @@ public class ClustersResource {
         }
 
         return returnResponse;
+    }
+
+    @Timed
+    @PUT
+    @Path("/flexupservice")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response flexUpservice(FlexUpServiceRequest request) {
+      Preconditions.checkNotNull(request,
+              "request object cannot be null or empty");
+
+      LOGGER.info("Received Flexup a Service Request");
+
+      Integer instances = request.getInstances();
+      String serviceName = request.getServiceName();
+
+      LOGGER.info("Instances: {}", instances);
+      LOGGER.info("Service: {}", serviceName);
+      
+      // Validate profile request
+      Response.ResponseBuilder response = Response.status(Response.Status.ACCEPTED);
+      
+      if (cfg.getServiceConfiguration(serviceName) == null) {
+        response.status(Response.Status.BAD_REQUEST)
+                .entity("Service does not exist: " + serviceName);
+        LOGGER.error("Provided service does not exist " + serviceName);
+        return response.build();
+      }
+      
+      if (!validateInstances(instances, response)) {
+        return response.build();
+      }
+
+      try {
+        this.myriadOperations.flexUpAService(instances, serviceName);
+      } catch (MyriadBadConfigurationException e) {
+        return response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+      }
+
+      return response.build();
     }
 
     @Timed
@@ -205,10 +256,44 @@ public class ClustersResource {
 
 
     private Integer getNumFlexedupNMs(String profile) {
-      NMProfile nmProfile = profileManager.get(profile);
-      return this.schedulerState.getActiveTaskIDsForProfile(nmProfile).size()
-                + this.schedulerState.getStagingTaskIDsForProfile(nmProfile).size()
-                + this.schedulerState.getPendingTaskIDsForProfile(nmProfile).size();
+      ServiceResourceProfile serviceProfile = profileManager.get(profile);
+      return this.schedulerState.getActiveTaskIDsForProfile(serviceProfile).size()
+                + this.schedulerState.getStagingTaskIDsForProfile(serviceProfile).size()
+                + this.schedulerState.getPendingTaskIDsForProfile(serviceProfile).size();
     }
 
+    @Timed
+    @PUT
+    @Path("/flexdownservice")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response flexDownservice(FlexDownServiceRequest request) {
+      Preconditions.checkNotNull(request,
+              "request object cannot be null or empty");
+      
+      Integer instances = request.getInstances();
+      String serviceName = request.getServiceName();
+      
+      LOGGER.info("Received flexdown request for service {}", serviceName);
+      LOGGER.info("Instances: " + instances);
+
+      Response.ResponseBuilder response = Response.status(Response.Status.ACCEPTED);
+
+      if (!validateInstances(instances, response)) {
+          return response.build();
+      }
+
+      // warn that number of requested instances isn't available
+      // but instances will still be flexed down
+      Integer flexibleInstances = this.myriadOperations.getFlexibleInstances(serviceName);
+      if (flexibleInstances < instances)  {
+          response.entity("Number of requested instances is greater than available.");
+          // just doing a simple check here. pass the requested number of instances
+          // to myriadOperations and let it sort out how many actually get flexxed down.
+          LOGGER.warn("Requested number of instances greater than available: {} < {}", flexibleInstances, instances);
+      }
+
+      this.myriadOperations.flexDownAService(instances, serviceName);
+      return response.build();
+    }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownServiceRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexDownServiceRequest.java
@@ -1,0 +1,63 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.api.model;
+
+import com.google.gson.Gson;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * Flex down an auxtask/service
+ */
+public class FlexDownServiceRequest {
+
+    @NotEmpty
+    public Integer instances;
+    
+    @NotEmpty
+    public String serviceName;
+
+    public FlexDownServiceRequest() {
+    }
+
+    public FlexDownServiceRequest(Integer instances, String serviceName) {
+        this.instances = instances;
+        this.serviceName = serviceName;
+    }
+
+    public Integer getInstances() {
+        return instances;
+    }
+
+    public void setInstances(Integer instances) {
+        this.instances = instances;
+    }
+
+    public String getServiceName() {
+      return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+      this.serviceName = serviceName;
+    }
+
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpClusterRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpClusterRequest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
- * Flex up request parameters
+ * Flex up an auxtask/service
  */
 public class FlexUpClusterRequest {
     @NotEmpty

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpServiceRequest.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/api/model/FlexUpServiceRequest.java
@@ -1,0 +1,61 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ebay.myriad.api.model;
+
+import com.google.gson.Gson;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * Flex up request parameters
+ */
+public class FlexUpServiceRequest {
+    @NotEmpty
+    public Integer instances;
+
+    @NotEmpty
+    public String serviceName;
+
+    public FlexUpServiceRequest() {
+    }
+    
+    public FlexUpServiceRequest(Integer instances, String profile) {
+        this.instances = instances;
+        this.serviceName = profile;
+    }
+
+    public Integer getInstances() {
+        return instances;
+    }
+
+    public void setInstances(Integer instances) {
+        this.instances = instances;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String profile) {
+        this.serviceName = profile;
+    }
+
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/MyriadBadConfigurationException.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/MyriadBadConfigurationException.java
@@ -1,0 +1,32 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.configuration;
+
+/**
+ * Myriad specific exception
+ *
+ */
+@SuppressWarnings("serial")
+public class MyriadBadConfigurationException extends Exception {
+
+  
+  public MyriadBadConfigurationException(String message) {
+    super(message);
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/MyriadConfiguration.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/MyriadConfiguration.java
@@ -120,6 +120,9 @@ public class MyriadConfiguration {
 
   @JsonProperty
   private NodeManagerConfiguration nodemanager;
+  
+  @JsonProperty
+  private Map<String, ServiceConfiguration> services;
 
   @JsonProperty
   @NotEmpty
@@ -202,7 +205,18 @@ public class MyriadConfiguration {
   public NodeManagerConfiguration getNodeManagerConfiguration() {
     return this.nodemanager;
   }
+  
+  public Map<String, ServiceConfiguration> getServiceConfigurations() {
+    return this.services;
+  }
 
+  public ServiceConfiguration getServiceConfiguration(String taskName) {
+    if (services == null) {
+      return null;
+    }
+    return this.services.get(taskName);
+  }
+  
   public MyriadExecutorConfiguration getMyriadExecutorConfiguration() {
     return this.executor;
   }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/NodeManagerConfiguration.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/NodeManagerConfiguration.java
@@ -21,6 +21,8 @@ public class NodeManagerConfiguration {
      * Default cpu for NodeManager JVM.
      */
     public static final double DEFAULT_NM_CPUS = 1;
+    
+    public static final String NM_TASK_PREFIX = "nm";
 
     /**
      * Translates to -Xmx for the NodeManager JVM.

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/ServiceConfiguration.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/configuration/ServiceConfiguration.java
@@ -1,0 +1,132 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.configuration;
+
+import java.util.Map;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+/**
+ * Configuration for any service/task to be started from Myriad Scheduler
+ *
+ */
+public class ServiceConfiguration {
+  
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceConfiguration.class);
+
+  public static final Double DEFAULT_CPU = 0.1;
+  
+  public static final Double DEFAULT_MEMORY = 256.0;
+  
+  /**
+   * Translates to -Xmx for the JVM.
+   */
+  @JsonProperty
+  protected Double jvmMaxMemoryMB;
+
+  /**
+   * Amount of CPU share given to  JVM. 
+   */
+  @JsonProperty
+  protected Double cpus;
+
+  /**
+   * Translates to jvm opts for the JVM.
+   */
+  @JsonProperty
+  protected String jvmOpts;
+
+  @JsonProperty
+  protected Map<String, Long> ports;
+  
+  /**
+   * If we will have some services
+   * that are not easy to express just by properties
+   * we can use this one to have a specific implementation
+   */
+  @JsonProperty
+  protected String taskFactoryImplName;
+  
+  @JsonProperty
+  protected String envSettings;
+  
+  @JsonProperty
+  @NotEmpty
+  protected String taskName;
+  
+  @JsonProperty
+  protected Integer maxInstances;
+  
+  @JsonProperty
+  protected String command;
+  
+  @JsonProperty
+  protected String serviceOptsName;
+  
+  
+  public Optional<Double> getJvmMaxMemoryMB() {
+      return Optional.fromNullable(jvmMaxMemoryMB);
+  }
+
+  public Optional<String> getJvmOpts() {
+      return Optional.fromNullable(jvmOpts);
+  }
+
+  public Optional<Double> getCpus() {
+      return Optional.fromNullable(cpus);
+  }
+
+  public String getTaskName() {
+    return taskName;
+  }
+
+  public void setTaskName(String taskName) {
+    this.taskName = taskName;
+  }
+
+  public Optional<String> getTaskFactoryImplName() {
+    return Optional.fromNullable(taskFactoryImplName);
+  }
+
+  public String getEnvSettings() {
+    return envSettings;
+  }
+  
+  public Optional<Map<String, Long>> getPorts() {
+    return Optional.fromNullable(ports);
+  }
+  
+  public Optional<Integer> getMaxInstances() {
+    return Optional.fromNullable(maxInstances);
+  }
+
+  public Optional<String> getCommand() {
+    return Optional.fromNullable(command);
+  }
+
+  public String getServiceOpts() {
+    return serviceOptsName;
+  }
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/DownloadNMExecutorCLGenImpl.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/DownloadNMExecutorCLGenImpl.java
@@ -42,12 +42,12 @@ public class DownloadNMExecutorCLGenImpl extends NMExecutorCLGenImpl {
   }
 
 @Override
-  public String generateCommandLine(NMProfile profile, NMPorts ports) {
+  public String generateCommandLine(ServiceResourceProfile profile, Ports ports) {
     StringBuilder cmdLine = new StringBuilder();
     LOGGER.info("Using remote distribution");
 
-    generateEnvironment(profile, ports);
-    appendNMExtractionCommands(cmdLine);
+    generateEnvironment(profile, (NMPorts) ports);
+    appendDistroExtractionCommands(cmdLine);
     appendCgroupsCmds(cmdLine);
     appendYarnHomeExport(cmdLine);
     appendUser(cmdLine);
@@ -56,7 +56,7 @@ public class DownloadNMExecutorCLGenImpl extends NMExecutorCLGenImpl {
     return cmdLine.toString();
   }
 
-  private void appendNMExtractionCommands(StringBuilder cmdLine) {
+  protected void appendDistroExtractionCommands(StringBuilder cmdLine) {
     /*
     TODO(darinj): Overall this is messier than I'd like. We can't let mesos untar the distribution, since
     it will change the permissions.  Instead we simply download the tarball and execute tar -xvpf. We also
@@ -81,7 +81,7 @@ public class DownloadNMExecutorCLGenImpl extends NMExecutorCLGenImpl {
       .append("/etc/hadoop/yarn-site.xml;");
   }
 
-  private void appendUser(StringBuilder cmdLine) {
+  protected void appendUser(StringBuilder cmdLine) {
     cmdLine.append(" sudo -E -u ").append(cfg.getFrameworkUser().get()).append(" -H");
   }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ExecutorCommandLineGenerator.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ExecutorCommandLineGenerator.java
@@ -22,5 +22,7 @@ package com.ebay.myriad.scheduler;
  * Interface to plugin multiple implementations for executor command generation  
  */
 public interface ExecutorCommandLineGenerator {
-    String generateCommandLine(NMProfile profile, NMPorts ports);
+    String generateCommandLine(ServiceResourceProfile profile, Ports ports);
+    
+    String getConfigurationUrl();
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ExtendedResourceProfile.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ExtendedResourceProfile.java
@@ -1,0 +1,65 @@
+package com.ebay.myriad.scheduler;
+
+import com.google.gson.Gson;
+
+/**
+ * Extended ServiceResourceProfile for services that need to pass set of resources downstream
+ * currently the only such service is NodeManager
+ *
+ */
+public class ExtendedResourceProfile extends ServiceResourceProfile {
+
+  private NMProfile childProfile;
+
+  /**
+   * 
+   * @param childProfile - should be null
+   * @param cpu
+   * @param mem
+   * will throw NullPoiterException if childProfile is null
+   */
+  public ExtendedResourceProfile(NMProfile childProfile, Double cpu, Double mem) {
+    super(childProfile.getName(), cpu, mem);
+    this.childProfile = childProfile;
+    this.className = ExtendedResourceProfile.class.getName();
+  }
+
+  public NMProfile getChildProfile() {
+    return childProfile;
+  }
+
+  public void setChildProfile(NMProfile nmProfile) {
+    this.childProfile = nmProfile;
+  }
+  
+  @Override
+  public String getName() {
+    return childProfile.getName();
+  }
+
+  @Override
+  public Double getCpus() {
+    return childProfile.getCpus().doubleValue();
+  }
+
+  @Override
+  public Double getMemory() {
+    return childProfile.getMemory().doubleValue();
+  }
+
+  @Override
+  public Double getAggregateMemory() {
+    return memory + childProfile.getMemory();
+  }
+  
+  @Override
+  public Double getAggregateCpu() {
+    return cpus + childProfile.getCpus();
+  }
+
+  @Override
+  public String toString() {
+      Gson gson = new Gson();
+      return gson.toJson(this);
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/MyriadOperations.java
@@ -15,13 +15,19 @@
  */
 package com.ebay.myriad.scheduler;
 
+import com.ebay.myriad.configuration.MyriadBadConfigurationException;
+import com.ebay.myriad.configuration.ServiceConfiguration;
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
 import com.ebay.myriad.policy.NodeScaleDownPolicy;
 import com.ebay.myriad.scheduler.constraints.Constraint;
 import com.ebay.myriad.scheduler.constraints.LikeConstraint;
 import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Myriad scheduler operations
@@ -36,58 +43,157 @@ import java.util.List;
 public class MyriadOperations {
     private static final Logger LOGGER = LoggerFactory.getLogger(MyriadOperations.class);
     private final SchedulerState schedulerState;
+
+    private MyriadConfiguration cfg;
     private NodeScaleDownPolicy nodeScaleDownPolicy;
 
     @Inject
-    public MyriadOperations(SchedulerState schedulerState,
+    public MyriadOperations(MyriadConfiguration cfg,
+                            SchedulerState schedulerState,
                             NodeScaleDownPolicy nodeScaleDownPolicy) {
+      this.cfg = cfg;
       this.schedulerState = schedulerState;
       this.nodeScaleDownPolicy = nodeScaleDownPolicy;
     }
 
-    public void flexUpCluster(NMProfile profile, int instances, Constraint constraint) {
+    public void flexUpCluster(ServiceResourceProfile serviceResourceProfile, int instances, Constraint constraint) {
         Collection<NodeTask> nodes = new HashSet<>();
         for (int i = 0; i < instances; i++) {
-            nodes.add(new NodeTask(profile, constraint));
+          NodeTask nodeTask = new NodeTask(serviceResourceProfile, constraint);
+          nodeTask.setTaskPrefix(NodeManagerConfiguration.NM_TASK_PREFIX);
+          nodes.add(nodeTask);
         }
 
+        LOGGER.info("Adding {} NM instances to cluster", nodes.size());
         this.schedulerState.addNodes(nodes);
     }
 
-    public void flexDownCluster(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+    public void flexDownCluster(ServiceResourceProfile serviceResourceProfile, Constraint constraint, int numInstancesToScaleDown) {
         // Flex down Pending tasks, if any
         int numPendingTasksScaledDown = flexDownPendingTasks(
-            profile, constraint, numInstancesToScaleDown);
+            serviceResourceProfile, constraint, numInstancesToScaleDown);
 
         // Flex down Staging tasks, if any
         int numStagingTasksScaledDown = flexDownStagingTasks(
-            profile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown);
+            serviceResourceProfile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown);
 
         // Flex down Active tasks, if any
         int numActiveTasksScaledDown = flexDownActiveTasks(
-            profile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown - numStagingTasksScaledDown);
+            serviceResourceProfile, constraint, numInstancesToScaleDown - numPendingTasksScaledDown - numStagingTasksScaledDown);
 
         if (numActiveTasksScaledDown + numStagingTasksScaledDown + numPendingTasksScaledDown == 0) {
           LOGGER.info("No Node Managers with profile '{}' and constraint '{}' found for scaling down.",
-              profile.getName(), constraint == null ? "null" : constraint.toString());
+              serviceResourceProfile.getName(), constraint == null ? "null" : constraint.toString());
         } else {
           LOGGER.info("Flexed down {} active, {} staging  and {} pending Node Managers with " +
               "'{}' profile and constraint '{}'.", numActiveTasksScaledDown, numStagingTasksScaledDown,
-              numPendingTasksScaledDown, profile.getName(), constraint == null ? "null" : constraint.toString());
+              numPendingTasksScaledDown, serviceResourceProfile.getName(), constraint == null ? "null" : constraint.toString());
         }
     }
 
-    private int flexDownPendingTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+    /**
+     * Flexup a service
+     * @param instances
+     * @param serviceName
+     */
+    public void flexUpAService(int instances, String serviceName) throws MyriadBadConfigurationException {
+      final ServiceConfiguration auxTaskConf = cfg.getServiceConfiguration(serviceName);
+      
+      int totalflexInstances = instances + getFlexibleInstances(serviceName);
+      Integer maxInstances = auxTaskConf.getMaxInstances().orNull();
+      if (maxInstances != null && maxInstances > 0) {
+        // check number of instances
+        // sum of active, staging, pending should be < maxInstances
+        if (totalflexInstances > maxInstances) {
+          LOGGER.error("Current number of active, staging, pending and requested instances: {}"
+              + ", while it is greater then max instances allowed: {}", totalflexInstances, maxInstances);
+            throw new MyriadBadConfigurationException("Current number of active, staging, pending instances and requested: "
+            + totalflexInstances + ", while it is greater then max instances allowed: " + maxInstances);          
+        }
+      }
+
+      final Double cpu = auxTaskConf.getCpus().or(ServiceConfiguration.DEFAULT_CPU);
+      final Double mem = auxTaskConf.getJvmMaxMemoryMB().or(ServiceConfiguration.DEFAULT_MEMORY);
+      
+      Collection<NodeTask> nodes = new HashSet<>();
+      for (int i = 0; i < instances; i++) {
+        NodeTask nodeTask = new NodeTask(new ServiceResourceProfile(serviceName, cpu, mem), null);
+        nodeTask.setTaskPrefix(serviceName);
+        nodes.add(nodeTask);
+      }
+
+      LOGGER.info("Adding {} {} instances to cluster", nodes.size(), serviceName);
+      this.schedulerState.addNodes(nodes);
+    }
+    
+    /**
+     * Flexing down any service defined in the configuration
+     * @param numInstancesToScaleDown
+     * @param serviceName - name of the service
+     */
+    public void flexDownAService(int numInstancesToScaleDown, String serviceName) {
+      LOGGER.info("About to flex down {} instances of {}", numInstancesToScaleDown, serviceName);
+
+      int numScaledDown = 0;
+      
+      // Flex down Pending tasks, if any
+      if (numScaledDown < numInstancesToScaleDown) {
+        Set<Protos.TaskID> pendingTasks = Sets.newHashSet(this.schedulerState.getPendingTaskIds(serviceName));
+
+        for (Protos.TaskID taskId : pendingTasks) {
+            this.schedulerState.makeTaskKillable(taskId);
+            numScaledDown++;
+            if (numScaledDown >= numInstancesToScaleDown) {
+                break;
+            }
+        }
+      }
+      int numPendingTasksScaledDown = numScaledDown;
+      
+      // Flex down Staging tasks, if any
+      if (numScaledDown < numInstancesToScaleDown) {
+          Set<Protos.TaskID> stagingTasks = Sets.newHashSet(this.schedulerState.getStagingTaskIds(serviceName));
+
+          for (Protos.TaskID taskId : stagingTasks) {
+              this.schedulerState.makeTaskKillable(taskId);
+              numScaledDown++;
+              if (numScaledDown >= numInstancesToScaleDown) {
+                  break;
+              }
+          }
+      }
+      int numStagingTasksScaledDown = numScaledDown - numPendingTasksScaledDown;
+
+      Set<NodeTask> activeTasks = Sets.newHashSet(this.schedulerState.getActiveTasksByType(serviceName));
+      if (numScaledDown < numInstancesToScaleDown) {
+        for (NodeTask nodeTask : activeTasks) {
+          this.schedulerState.makeTaskKillable(nodeTask.getTaskStatus().getTaskId());
+          numScaledDown++;
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Marked NodeTask {} on host {} for kill.",
+                nodeTask.getTaskStatus().getTaskId(), nodeTask.getHostname());
+          }
+          if (numScaledDown >= numInstancesToScaleDown) {
+            break;
+          }
+        }
+      }
+      
+      LOGGER.info("Flexed down {} of {} instances including {} staging instances, and {} pending instances of {}",
+              numScaledDown, numInstancesToScaleDown, numStagingTasksScaledDown, numPendingTasksScaledDown, serviceName);
+    }
+    
+    private int flexDownPendingTasks(ServiceResourceProfile profile, Constraint constraint, int numInstancesToScaleDown) {
       return numInstancesToScaleDown > 0 ? flexDownTasks(schedulerState.getPendingTaskIDsForProfile(profile),
           profile, constraint, numInstancesToScaleDown) : 0;
     }
 
-  private int flexDownStagingTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+  private int flexDownStagingTasks(ServiceResourceProfile profile, Constraint constraint, int numInstancesToScaleDown) {
       return numInstancesToScaleDown > 0 ? flexDownTasks(schedulerState.getStagingTaskIDsForProfile(profile),
           profile, constraint, numInstancesToScaleDown) : 0;
     }
 
-    private int flexDownActiveTasks(NMProfile profile, Constraint constraint, int numInstancesToScaleDown) {
+    private int flexDownActiveTasks(ServiceResourceProfile profile, Constraint constraint, int numInstancesToScaleDown) {
       if (numInstancesToScaleDown > 0) {
         List<Protos.TaskID> activeTasksForProfile = Lists.newArrayList(schedulerState.getActiveTaskIDsForProfile(profile));
         nodeScaleDownPolicy.apply(activeTasksForProfile);
@@ -96,7 +202,7 @@ public class MyriadOperations {
       return 0;
     }
 
-  private int flexDownTasks(Collection<Protos.TaskID> taskIDs, NMProfile profile,
+  private int flexDownTasks(Collection<Protos.TaskID> taskIDs, ServiceResourceProfile profile,
                               Constraint constraint, int numInstancesToScaleDown) {
       int numInstancesScaledDown = 0;
       for (Protos.TaskID taskID : taskIDs) {
@@ -132,6 +238,12 @@ public class MyriadOperations {
       }
     }
     return true;
+  } 
+ 
+  public Integer getFlexibleInstances(String taskPrefix) {
+      return this.schedulerState.getActiveTaskIds(taskPrefix).size()
+              + this.schedulerState.getStagingTaskIds(taskPrefix).size()
+              + this.schedulerState.getPendingTaskIds(taskPrefix).size();
   }
 
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMExecutorCLGenImpl.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMExecutorCLGenImpl.java
@@ -21,6 +21,7 @@ package com.ebay.myriad.scheduler;
 import java.util.Map;
 import java.util.HashMap;
 
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,10 +100,10 @@ public class NMExecutorCLGenImpl implements ExecutorCommandLineGenerator {
   }
 
   @Override
-  public String generateCommandLine(NMProfile profile, NMPorts ports) {
+  public String generateCommandLine(ServiceResourceProfile profile, Ports ports) {
     StringBuilder cmdLine = new StringBuilder();
 
-    generateEnvironment(profile, ports);
+    generateEnvironment(profile, (NMPorts) ports);
     appendCgroupsCmds(cmdLine);
     appendYarnHomeExport(cmdLine);
     appendEnvForNM(cmdLine);
@@ -110,7 +111,7 @@ public class NMExecutorCLGenImpl implements ExecutorCommandLineGenerator {
     return cmdLine.toString();
   }
 
-  protected void generateEnvironment(NMProfile profile, NMPorts ports) {
+  protected void generateEnvironment(ServiceResourceProfile profile, NMPorts ports) {
     //yarnEnvironemnt configuration from yaml file
     Map<String, String> yarnEnvironmentMap = cfg.getYarnEnvironment();
     if (yarnEnvironmentMap != null) {
@@ -188,4 +189,22 @@ public class NMExecutorCLGenImpl implements ExecutorCommandLineGenerator {
       }
   }
 
+  @Override
+  public String getConfigurationUrl() {
+    YarnConfiguration conf = new YarnConfiguration();
+    String httpPolicy = conf.get(TaskFactory.YARN_HTTP_POLICY);
+    if (httpPolicy != null && httpPolicy.equals(TaskFactory.YARN_HTTP_POLICY_HTTPS_ONLY)) {
+      String address = conf.get(TaskFactory.YARN_RESOURCEMANAGER_WEBAPP_HTTPS_ADDRESS);
+      if (address == null || address.isEmpty()) {
+        address = conf.get(TaskFactory.YARN_RESOURCEMANAGER_HOSTNAME) + ":8090";
+      }
+      return "https://" + address + "/conf";
+    } else {
+      String address = conf.get(TaskFactory.YARN_RESOURCEMANAGER_WEBAPP_ADDRESS);
+      if (address == null || address.isEmpty()) {
+        address = conf.get(TaskFactory.YARN_RESOURCEMANAGER_HOSTNAME) + ":8088";
+      }
+      return "http://" + address + "/conf";
+    }
+  }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMPorts.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMPorts.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * Helper class for dynamically assigning ports to nodemanager
  */
-public class NMPorts {
+public class NMPorts implements Ports {
     private static final String NM_RPC_PORT_KEY = "nm.rpc.port";
     private static final String NM_LOCALIZER_PORT_KEY = "nm.localizer.port";
     private static final String NM_WEBAPP_HTTP_PORT_KEY = "nm.webapp.http.port";

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMTaskFactoryAnnotation.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/NMTaskFactoryAnnotation.java
@@ -1,0 +1,34 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.scheduler;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
+/**
+ * NMTaskFactory annotation that allows to bind TaskFactory to NM specific implementation
+ *
+ */
+@BindingAnnotation @Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface NMTaskFactoryAnnotation {}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Ports.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Ports.java
@@ -1,0 +1,9 @@
+package com.ebay.myriad.scheduler;
+
+/**
+ * Generic interface to represent ports
+ *
+ */
+public interface Ports {
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Rebalancer.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/Rebalancer.java
@@ -17,6 +17,11 @@ package com.ebay.myriad.scheduler;
 
 import com.ebay.myriad.state.SchedulerState;
 import javax.inject.Inject;
+import java.util.Set;
+
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
+
+import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,12 +34,12 @@ public class Rebalancer implements Runnable {
 
     private final SchedulerState schedulerState;
     private final MyriadOperations myriadOperations;
-    private final NMProfileManager profileManager;
+    private final ServiceProfileManager profileManager;
 
     @Inject
     public Rebalancer(SchedulerState schedulerState,
                       MyriadOperations myriadOperations,
-                      NMProfileManager profileManager) {
+                      ServiceProfileManager profileManager) {
         this.schedulerState = schedulerState;
         this.myriadOperations = myriadOperations;
         this.profileManager = profileManager;
@@ -42,8 +47,10 @@ public class Rebalancer implements Runnable {
 
     @Override
     public void run() {
-        LOGGER.info("Active {}, Pending {}", schedulerState.getActiveTaskIds().size(), schedulerState.getPendingTaskIds().size());
-        if (schedulerState.getActiveTaskIds().size() < 1 && schedulerState.getPendingTaskIds().size() < 1) {
+      final Set<Protos.TaskID> activeIds = schedulerState.getActiveTaskIds(NodeManagerConfiguration.NM_TASK_PREFIX);
+      final Set<Protos.TaskID> pendingIds = schedulerState.getPendingTaskIds(NodeManagerConfiguration.NM_TASK_PREFIX);
+        LOGGER.info("Active {}, Pending {}", activeIds.size(), pendingIds.size());
+        if (activeIds.size() < 1 && pendingIds.size() < 1) {
             myriadOperations.flexUpCluster(profileManager.get("small"), 1, null);
         }
 //            RestAdapter restAdapter = new RestAdapter.Builder()

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/SchedulerUtils.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/SchedulerUtils.java
@@ -15,9 +15,11 @@
  */
 package com.ebay.myriad.scheduler;
 
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
 import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.base.Preconditions;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -31,8 +33,8 @@ import java.util.Collection;
 public class SchedulerUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerUtils.class);
 
-    public static boolean isUniqueHostname(Protos.OfferOrBuilder offer,
-                                           Collection<NodeTask> tasks) {
+    public static boolean isUniqueHostname(Protos.OfferOrBuilder offer, NodeTask taskToLaunch, 
+        Collection<NodeTask> tasks) {
         Preconditions.checkArgument(offer != null);
         String offerHostname = offer.getHostname();
 
@@ -41,8 +43,10 @@ public class SchedulerUtils {
         }
         boolean uniqueHostname = true;
         for (NodeTask task : tasks) {
-            if (offerHostname.equalsIgnoreCase(task.getHostname())) {
+            if (offerHostname.equalsIgnoreCase(task.getHostname()) &&
+                task.getTaskPrefix().equalsIgnoreCase(taskToLaunch.getTaskPrefix())) {
                 uniqueHostname = false;
+                break;
             }
         }
         LOGGER.debug("Offer's hostname {} is unique: {}", offerHostname, uniqueHostname);
@@ -58,7 +62,7 @@ public class SchedulerUtils {
      * @return
      */
     public static boolean isEligibleForFineGrainedScaling(String hostName, SchedulerState state) {
-      for (NodeTask activeNMTask : state.getActiveTasks()) {
+      for (NodeTask activeNMTask : state.getActiveTasksByType(NodeManagerConfiguration.NM_TASK_PREFIX)) {
         if (activeNMTask.getProfile().getCpus() == 0 &&
             activeNMTask.getProfile().getMemory() == 0 &&
             activeNMTask.getHostname().equals(hostName)) {

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceCommandLineGenerator.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceCommandLineGenerator.java
@@ -1,0 +1,42 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ebay.myriad.scheduler;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+
+/**
+ * CommandLineGenerator for any aux service launched by Myriad as binary distro
+ *
+ */
+public class ServiceCommandLineGenerator extends DownloadNMExecutorCLGenImpl {
+
+  
+  public ServiceCommandLineGenerator(MyriadConfiguration cfg,
+      String nodeManagerUri) {
+    super(cfg, nodeManagerUri);
+  }
+
+  @Override
+  public String generateCommandLine(ServiceResourceProfile profile, Ports ports) {
+    StringBuilder strB = new StringBuilder();
+    appendDistroExtractionCommands(strB);
+    appendUser(strB);
+    return strB.toString();
+  }
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceProfileManager.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceProfileManager.java
@@ -1,0 +1,39 @@
+package com.ebay.myriad.scheduler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * Class to keep all the ServiceResourceProfiles together
+ *
+ */
+public class ServiceProfileManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceProfileManager.class);
+
+  private Map<String, ServiceResourceProfile> profiles = new ConcurrentHashMap<>();
+
+  public ServiceResourceProfile get(String name) {
+      return profiles.get(name);
+  }
+
+  public void add(ServiceResourceProfile profile) {
+      LOGGER.info("Adding profile {} with CPU: {} and Memory: {}",
+              profile.getName(), profile.getCpus(), profile.getMemory());
+      profiles.put(profile.getName(), profile);
+  }
+
+  public boolean exists(String name) {
+      return this.profiles.containsKey(name);
+  }
+
+  public String toString() {
+      Gson gson = new Gson();
+      return gson.toJson(this);
+  }
+
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceResourceProfile.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceResourceProfile.java
@@ -1,0 +1,117 @@
+package com.ebay.myriad.scheduler;
+
+import java.lang.reflect.Type;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ * Resource Profile for any service 
+ *
+ */
+public class ServiceResourceProfile {
+
+  protected final String name;
+
+  /**
+   * Number of CPU needed to run a service
+   */
+  protected final Double cpus;
+
+  /**
+   * Memory in MB needed to run a service
+   */
+  protected final Double memory;
+
+  protected Double executorCpu = 0.0;
+  
+  protected Double executorMemory = 0.0;
+  
+  protected String className;
+    
+  public ServiceResourceProfile(String name, Double cpu, Double mem) {
+    this.name = name;
+    this.cpus = cpu;
+    this.memory = mem;
+    this.className = ServiceResourceProfile.class.getName();
+  }
+
+
+  public String getName() {
+    return name;
+  }
+
+  public Double getCpus() {
+    return cpus;
+  }
+
+  public Double getMemory() {
+    return memory;
+  }
+  
+  public Double getAggregateMemory() {
+    return memory;
+  }
+  
+  public Double getAggregateCpu() {
+    return cpus;
+  }
+  
+  public Double getExecutorCpu() {
+    return executorCpu;
+  }
+
+  public void setExecutorCpu(Double executorCpu) {
+    this.executorCpu = executorCpu;
+  }
+
+  public Double getExecutorMemory() {
+    return executorMemory;
+  }
+
+  public void setExecutorMemory(Double executorMemory) {
+    this.executorMemory = executorMemory;
+  }
+
+
+  @Override
+  public String toString() {
+      Gson gson = new Gson();
+      return gson.toJson(this);
+  }
+  
+  /**
+   * Custom serializer to help with deserialization of class hierarchy
+   * since at the point of deserialization we don't know class of the data 
+   * that is being deserialized
+   *
+   */
+  public static class CustomDeserializer implements JsonDeserializer<ServiceResourceProfile> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomDeserializer.class);
+    
+    @Override
+    public ServiceResourceProfile deserialize(JsonElement json, Type typeOfT,
+        JsonDeserializationContext context) throws JsonParseException {
+      String type = json.getAsJsonObject().get("className").getAsString();
+      try {
+        @SuppressWarnings("rawtypes")
+        Class c = Class.forName(type);
+        if (ServiceResourceProfile.class.equals(c)) {
+          return new Gson().fromJson(json, typeOfT);
+        }
+        ServiceResourceProfile profile = context.deserialize(json, c);
+        return profile;
+      } catch (ClassNotFoundException e) {
+        LOGGER.error("Classname is not found", e);
+      }
+      return null;
+    }
+    
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceTaskConstraints.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceTaskConstraints.java
@@ -1,0 +1,36 @@
+package com.ebay.myriad.scheduler;
+
+import java.util.Map;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.configuration.ServiceConfiguration;
+
+/**
+ * ServiceTaskConstraints is an implementation of TaskConstraints for a service
+ * at this point constraints are on ports
+ * Later on there may be other types of constraints added
+ *
+ */
+public class ServiceTaskConstraints implements TaskConstraints {
+
+  private int portsCount;
+  
+  public ServiceTaskConstraints(MyriadConfiguration cfg, String taskPrefix) {
+    this.portsCount = 0;
+    Map<String, ServiceConfiguration> auxConfigs = cfg.getServiceConfigurations();
+    if (auxConfigs == null) {
+      return;
+    }
+    ServiceConfiguration serviceConfig = auxConfigs.get(taskPrefix);
+    if (serviceConfig != null) {
+      if (serviceConfig.getPorts().isPresent()) {
+        this.portsCount = serviceConfig.getPorts().get().size();
+      }
+    }
+  }
+  
+  @Override
+  public int portsCount() {
+    return portsCount;
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceTaskFactoryImpl.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/ServiceTaskFactoryImpl.java
@@ -1,0 +1,266 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ebay.myriad.scheduler;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.inject.Inject;
+
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.Value;
+import org.apache.mesos.Protos.CommandInfo.URI;
+import org.apache.mesos.Protos.Value.Scalar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.configuration.MyriadExecutorConfiguration;
+import com.ebay.myriad.configuration.ServiceConfiguration;
+import com.ebay.myriad.state.NodeTask;
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Generic Service Class that allows to create a service solely base don the configuration
+ * Main properties of configuration are:
+ * 1. command to run
+ * 2. Additional env. variables to set (serviceOpts)
+ * 3. ports to use with names of the properties
+ * 4. TODO (yufeldman) executor info 
+ *
+ */
+public class ServiceTaskFactoryImpl implements TaskFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTaskFactoryImpl.class);
+    
+  public static final long DEFAULT_PORT_NUMBER = 0;
+  
+  private MyriadConfiguration cfg;
+  @SuppressWarnings("unused")
+  private TaskUtils taskUtils;
+  private ServiceCommandLineGenerator clGenerator;
+
+  @Inject
+  public ServiceTaskFactoryImpl(MyriadConfiguration cfg, TaskUtils taskUtils) {
+    this.cfg = cfg;
+    this.taskUtils = taskUtils;
+    this.clGenerator = new ServiceCommandLineGenerator(cfg, cfg.getMyriadExecutorConfiguration().getNodeManagerUri().orNull());
+  }
+
+  @Override
+  public TaskInfo createTask(Offer offer, FrameworkID frameworkId,
+    TaskID taskId, NodeTask nodeTask) {
+    Objects.requireNonNull(offer, "Offer should be non-null");
+    Objects.requireNonNull(nodeTask, "NodeTask should be non-null");
+
+    ServiceConfiguration serviceConfig = 
+        cfg.getServiceConfiguration(nodeTask.getTaskPrefix());
+    
+    Objects.requireNonNull(serviceConfig, "ServiceConfig should be non-null");
+    Objects.requireNonNull(serviceConfig.getCommand().orNull(), "command for ServiceConfig should be non-null");
+    
+    final String serviceHostName = "0.0.0.0";
+    final String serviceEnv = serviceConfig.getEnvSettings();
+    final String rmHostName = System.getProperty(YARN_RESOURCEMANAGER_HOSTNAME);
+    List<Long> additionalPortsNumbers = null;
+    
+    final StringBuilder strB = new StringBuilder("env ");
+    if (serviceConfig.getServiceOpts() != null) {
+      strB.append(serviceConfig.getServiceOpts()).append("=");
+      
+      strB.append("\"");
+      if (rmHostName != null && !rmHostName.isEmpty()) {
+        strB.append("-D" + YARN_RESOURCEMANAGER_HOSTNAME + "=" + rmHostName + " ");
+      }
+      
+      Map<String, Long> ports = serviceConfig.getPorts().orNull();
+      if (ports != null && !ports.isEmpty()) {
+        int neededPortsCount = 0;
+        for (Map.Entry<String, Long> portEntry : ports.entrySet()) {
+          Long port = portEntry.getValue();
+          if (port == DEFAULT_PORT_NUMBER) {
+            neededPortsCount++;
+          }
+        }
+        // use provided ports
+        additionalPortsNumbers = getAvailablePorts(offer, neededPortsCount);
+        LOGGER.info("No specified ports found or number of specified ports is not enough. Using ports from Mesos Offers: {}", additionalPortsNumbers);
+        int index = 0;
+        for (Map.Entry<String, Long> portEntry : ports.entrySet()) {
+          String portProperty = portEntry.getKey();
+          Long port = portEntry.getValue();
+          if (port == DEFAULT_PORT_NUMBER) {
+            port = additionalPortsNumbers.get(index++);
+          }
+          strB.append("-D" + portProperty + "=" + serviceHostName + ":" + port + " ");
+        }
+      }     
+      strB.append(serviceEnv);
+      strB.append("\"");
+    }
+
+    strB.append(" ");
+    strB.append(serviceConfig.getCommand().get());
+    
+    CommandInfo commandInfo = createCommandInfo(nodeTask.getProfile(), strB.toString());
+
+    LOGGER.info("Command line for service: {} is: {}", nodeTask.getTaskPrefix(), strB.toString());
+    
+    Scalar taskMemory = Scalar.newBuilder()
+        .setValue(nodeTask.getProfile().getMemory())
+        .build();
+    Scalar taskCpus = Scalar.newBuilder()
+        .setValue(nodeTask.getProfile().getCpus())
+        .build();
+
+    TaskInfo.Builder taskBuilder = TaskInfo.newBuilder();
+    
+    taskBuilder.setName(nodeTask.getTaskPrefix())
+        .setTaskId(taskId)
+        .setSlaveId(offer.getSlaveId())
+        .addResources(
+            Resource.newBuilder().setName("cpus")
+            .setType(Value.Type.SCALAR)
+            .setScalar(taskCpus)
+            .build())
+        .addResources(
+            Resource.newBuilder().setName("mem")
+            .setType(Value.Type.SCALAR)
+            .setScalar(taskMemory)
+            .build());
+    
+    if (additionalPortsNumbers != null && !additionalPortsNumbers.isEmpty()) {
+      // set ports
+      Value.Ranges.Builder valueRanger = Value.Ranges.newBuilder();
+      for (Long port : additionalPortsNumbers) {
+        valueRanger.addRange(Value.Range.newBuilder()
+                .setBegin(port)
+                .setEnd(port));
+      }
+      
+      taskBuilder.addResources(Resource.newBuilder().setName("ports")
+          .setType(Value.Type.RANGES)
+          .setRanges(valueRanger.build()));
+    }
+    taskBuilder.setCommand(commandInfo);
+    return taskBuilder.build();
+  }
+
+  @VisibleForTesting
+  CommandInfo createCommandInfo(ServiceResourceProfile profile, String executorCmd) {
+    MyriadExecutorConfiguration myriadExecutorConfiguration = cfg.getMyriadExecutorConfiguration();
+    CommandInfo.Builder commandInfo = CommandInfo.newBuilder();
+    Map<String, String> envVars = cfg.getYarnEnvironment();
+    if (envVars != null && !envVars.isEmpty()) {
+      org.apache.mesos.Protos.Environment.Builder yarnHomeB = 
+          org.apache.mesos.Protos.Environment.newBuilder();
+      for (Map.Entry<String, String> envEntry : envVars.entrySet()) {
+        org.apache.mesos.Protos.Environment.Variable.Builder yarnEnvB = 
+            org.apache.mesos.Protos.Environment.Variable.newBuilder();
+        yarnEnvB.setName(envEntry.getKey()).setValue(envEntry.getValue());
+        yarnHomeB.addVariables(yarnEnvB.build());
+      }
+      commandInfo.mergeEnvironment(yarnHomeB.build());
+    }
+
+    if (myriadExecutorConfiguration.getNodeManagerUri().isPresent()) {
+      //Both FrameworkUser and FrameworkSuperuser to get all of the directory permissions correct.
+      if (!(cfg.getFrameworkUser().isPresent() && cfg.getFrameworkSuperUser().isPresent())) {
+        throw new RuntimeException("Trying to use remote distribution, but frameworkUser" +
+            "and/or frameworkSuperUser not set!");
+      }
+
+      LOGGER.info("Using remote distribution");
+      String clGeneratedCommand = clGenerator.generateCommandLine(profile, null);
+      
+      String nmURIString = myriadExecutorConfiguration.getNodeManagerUri().get();
+
+      //Concatenate all the subcommands
+      String cmd = clGeneratedCommand + " " + executorCmd;
+
+      //get the nodemanagerURI
+      //We're going to extract ourselves, so setExtract is false
+      LOGGER.info("Getting Hadoop distribution from:" + nmURIString);
+      URI nmUri = URI.newBuilder().setValue(nmURIString).setExtract(false)
+          .build();
+
+      //get configs directly from resource manager
+      String configUrlString = clGenerator.getConfigurationUrl();
+      LOGGER.info("Getting config from:" + configUrlString);
+      URI configUri = URI.newBuilder().setValue(configUrlString)
+          .build();
+
+      LOGGER.info("Slave will execute command:" + cmd);
+      commandInfo.addUris(nmUri).addUris(configUri).setValue("echo \"" + cmd + "\";" + cmd);
+      commandInfo.setUser(cfg.getFrameworkSuperUser().get());
+
+    } else {
+      commandInfo.setValue(executorCmd);
+    }
+    return commandInfo.build();
+  }
+
+  @Override
+  public ExecutorInfo getExecutorInfoForSlave(FrameworkID frameworkId,
+      Offer offer, CommandInfo commandInfo) {
+    // TODO (yufeldman) if executor specified use it , otherwise return null
+    // nothing to implement here, since we are using default slave executor
+    return null;
+  }
+
+  /**
+   * Helper method to reserve ports
+   * @param offer
+   * @param requestedPorts
+   * @return
+   */
+  private List<Long> getAvailablePorts(Offer offer, int requestedPorts) {
+    if (requestedPorts == 0) {
+      return null;
+    }
+    final List<Long> returnedPorts = new ArrayList<>();
+    for (Resource resource : offer.getResourcesList()){
+      if (resource.getName().equals("ports")){
+        Iterator<Value.Range> itr = resource.getRanges().getRangeList().iterator();
+        while (itr.hasNext()) {
+          Value.Range range = itr.next();
+          if (range.getBegin() <= range.getEnd()) {
+            long i = range.getBegin();
+            while (i <= range.getEnd() && returnedPorts.size() < requestedPorts) {
+              returnedPorts.add(i);
+              i++;
+            }
+            if (returnedPorts.size() >= requestedPorts) { 
+              return returnedPorts;
+            }
+          }
+        }
+      }
+    }
+    // this is actually an error condition - we did not have enough ports to use
+    return returnedPorts;
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskConstraints.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskConstraints.java
@@ -1,0 +1,34 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.scheduler;
+
+/**
+ * Generic interface to represent some constraints that task can impose
+ * while figuring out whether to accept or reject the offer
+ * We may start small and then eventually add more constraints
+ */
+public interface TaskConstraints {
+
+  /**
+   * Required number of ports
+   * @return portsNumber
+   */
+  public int portsCount();
+  
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskConstraintsManager.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskConstraintsManager.java
@@ -1,0 +1,31 @@
+package com.ebay.myriad.scheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Factory class to keep map of the constraints
+ *
+ */
+public class TaskConstraintsManager {
+
+  /**
+   * Since all the additions will happen during init time, there is no need to make this map Concurrent
+   * if/when later on it will change we may need to change HashMap to Concurrent one
+   */
+  private Map<String, TaskConstraints> taskConstraintsMap = new HashMap<>();
+  
+  public TaskConstraints getConstraints(String taskPrefix) {
+    return taskConstraintsMap.get(taskPrefix);
+  }
+  
+  public void addTaskConstraints(final String taskPrefix, final TaskConstraints taskConstraints) {
+    if (taskConstraints != null) {
+      taskConstraintsMap.put(taskPrefix, taskConstraints);
+    }
+  }
+  
+  public boolean exists(String taskPrefix) {
+    return taskConstraintsMap.containsKey(taskPrefix);
+  }
+}

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskFactory.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskFactory.java
@@ -1,10 +1,17 @@
 package com.ebay.myriad.scheduler;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Objects;
+
+import javax.inject.Inject;
+
 import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.configuration.MyriadExecutorConfiguration;
 import com.ebay.myriad.state.NodeTask;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
+
 import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.CommandInfo.URI;
 import org.apache.mesos.Protos.ExecutorID;
@@ -19,16 +26,18 @@ import org.apache.mesos.Protos.Value.Scalar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Objects;
 
 /**
  * Creates Tasks based on mesos offers
  */
 public interface TaskFactory {
-  TaskInfo createTask(Offer offer, FrameworkID frameworkId,
+  static final String YARN_RESOURCEMANAGER_HOSTNAME = "yarn.resourcemanager.hostname";
+  static final String YARN_RESOURCEMANAGER_WEBAPP_ADDRESS = "yarn.resourcemanager.webapp.address";
+  static final String YARN_RESOURCEMANAGER_WEBAPP_HTTPS_ADDRESS = "yarn.resourcemanager.webapp.https.address";
+  static final String YARN_HTTP_POLICY = "yarn.http.policy";
+  static final String YARN_HTTP_POLICY_HTTPS_ONLY = "HTTPS_ONLY";
+
+  TaskInfo createTask(Offer offer, FrameworkID frameworkId, 
     TaskID taskId, NodeTask nodeTask);
 
   // TODO(Santosh): This is needed because the ExecutorInfo constructed
@@ -38,7 +47,7 @@ public interface TaskFactory {
   // ExecutorInfo, we wouldn't need this interface method.
   ExecutorInfo getExecutorInfoForSlave(FrameworkID frameworkId,
     Offer offer, CommandInfo commandInfo);
-
+  
   /**
    * Creates TaskInfo objects to launch NMs as mesos tasks.
    */
@@ -46,16 +55,12 @@ public interface TaskFactory {
     public static final String EXECUTOR_NAME = "myriad_task";
     public static final String EXECUTOR_PREFIX = "myriad_executor";
     public static final String YARN_NODEMANAGER_OPTS_KEY = "YARN_NODEMANAGER_OPTS";
-    private static final String YARN_RESOURCEMANAGER_HOSTNAME = "yarn.resourcemanager.hostname";
-    private static final String YARN_RESOURCEMANAGER_WEBAPP_ADDRESS = "yarn.resourcemanager.webapp.address";
-    private static final String YARN_RESOURCEMANAGER_WEBAPP_HTTPS_ADDRESS = "yarn.resourcemanager.webapp.https.address";
-    private static final String YARN_HTTP_POLICY = "yarn.http.policy";
-    private static final String YARN_HTTP_POLICY_HTTPS_ONLY = "HTTPS_ONLY";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NMTaskFactoryImpl.class);
     private MyriadConfiguration cfg;
     private TaskUtils taskUtils;
     private ExecutorCommandLineGenerator clGenerator;
+    private TaskConstraints constraints;
 
     @Inject
     public NMTaskFactoryImpl(MyriadConfiguration cfg, TaskUtils taskUtils,
@@ -63,6 +68,7 @@ public interface TaskFactory {
       this.cfg = cfg;
       this.taskUtils = taskUtils;
       this.clGenerator = clGenerator;
+      this.constraints = new NMTaskConstraints();
     }
 
     //Utility function to get the first NMPorts.expectedNumPorts number of ports of an offer
@@ -94,25 +100,8 @@ public interface TaskFactory {
       return new NMPorts(portArray);
     }
 
-    private String getConfigurationUrl() {
-      YarnConfiguration conf = new YarnConfiguration();
-      String httpPolicy = conf.get(YARN_HTTP_POLICY);
-      if (httpPolicy != null && httpPolicy.equals(YARN_HTTP_POLICY_HTTPS_ONLY)) {
-        String address = conf.get(YARN_RESOURCEMANAGER_WEBAPP_HTTPS_ADDRESS);
-        if (address == null || address.isEmpty()) {
-          address = conf.get(YARN_RESOURCEMANAGER_HOSTNAME) + ":8090";
-        }
-        return "https://" + address + "/conf";
-      } else {
-        String address = conf.get(YARN_RESOURCEMANAGER_WEBAPP_ADDRESS);
-        if (address == null || address.isEmpty()) {
-          address = conf.get(YARN_RESOURCEMANAGER_HOSTNAME) + ":8088";
-        }
-        return "http://" + address + "/conf";
-      }
-    }
-
-    private CommandInfo getCommandInfo(NMProfile profile, NMPorts ports) {
+    @VisibleForTesting
+    CommandInfo getCommandInfo(ServiceResourceProfile profile, NMPorts ports) {
       MyriadExecutorConfiguration myriadExecutorConfiguration = cfg.getMyriadExecutorConfiguration();
       CommandInfo.Builder commandInfo = CommandInfo.newBuilder();
       String cmd;
@@ -132,7 +121,7 @@ public interface TaskFactory {
         URI nmUri = URI.newBuilder().setValue(nodeManagerUri).setExtract(false).build();
 
         //get configs directly from resource manager
-        String configUrlString = getConfigurationUrl();
+        String configUrlString = clGenerator.getConfigurationUrl();
         LOGGER.info("Getting config from:" + configUrlString);
         URI configUri = URI.newBuilder().setValue(configUrlString)
           .build();
@@ -159,15 +148,15 @@ public interface TaskFactory {
       NMPorts ports = getPorts(offer);
       LOGGER.debug(ports.toString());
 
-      NMProfile profile = nodeTask.getProfile();
+      ServiceResourceProfile serviceProfile = nodeTask.getProfile();
       Scalar taskMemory = Scalar.newBuilder()
-          .setValue(taskUtils.getTaskMemory(profile))
+          .setValue(serviceProfile.getAggregateMemory())
           .build();
       Scalar taskCpus = Scalar.newBuilder()
-          .setValue(taskUtils.getTaskCpus(profile))
+          .setValue(serviceProfile.getAggregateCpu())
           .build();
 
-      CommandInfo commandInfo = getCommandInfo(profile, ports);
+      CommandInfo commandInfo = getCommandInfo(serviceProfile, ports);
       ExecutorInfo executorInfo = getExecutorInfoForSlave(frameworkId, offer, commandInfo);
 
       TaskInfo.Builder taskBuilder = TaskInfo.newBuilder()
@@ -234,6 +223,18 @@ public interface TaskFactory {
                   .setType(Value.Type.SCALAR)
                   .setScalar(executorMemory).build())
           .setExecutorId(executorId).build();
+    }
+  }
+  
+  /**
+   * Implement NM Task Constraints
+   *
+   */
+  public static class NMTaskConstraints implements TaskConstraints {
+
+    @Override
+    public int portsCount() {
+      return NMPorts.expectedNumPorts();
     }
   }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskUtils.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/TaskUtils.java
@@ -15,11 +15,14 @@
  */
 package com.ebay.myriad.scheduler;
 
+import com.ebay.myriad.configuration.ServiceConfiguration;
+import com.ebay.myriad.configuration.MyriadBadConfigurationException;
 import com.ebay.myriad.configuration.MyriadConfiguration;
 import com.ebay.myriad.configuration.MyriadExecutorConfiguration;
 import com.ebay.myriad.configuration.NodeManagerConfiguration;
 import com.ebay.myriad.executor.MyriadExecutorDefaults;
 import com.google.common.base.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -44,6 +47,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -181,4 +185,32 @@ public class TaskUtils {
         return getAggregateMemory(profile) - getExecutorMemory();
     }
 
+    public double getAuxTaskCpus(NMProfile profile, String taskName) throws MyriadBadConfigurationException {
+      if (taskName.startsWith(NodeManagerConfiguration.NM_TASK_PREFIX)) {
+        return getAggregateCpus(profile);
+      }
+      ServiceConfiguration auxConf = cfg.getServiceConfiguration(taskName);
+      if (auxConf == null) {
+        throw new MyriadBadConfigurationException("Can not find profile for task name: " + taskName);
+      }
+      if (!auxConf.getCpus().isPresent()) {
+        throw new MyriadBadConfigurationException("cpu is not defined for task with name: " + taskName);
+      }
+      return auxConf.getCpus().get();
+    }
+    
+    public double getAuxTaskMemory(NMProfile profile, String taskName) throws MyriadBadConfigurationException {
+      if (taskName.startsWith(NodeManagerConfiguration.NM_TASK_PREFIX)) {
+        return getAggregateMemory(profile);
+      }
+      ServiceConfiguration auxConf = cfg.getServiceConfiguration(taskName);
+      if (auxConf == null) {
+        throw new MyriadBadConfigurationException("Can not find profile for task name: " + taskName);
+      }
+      if (!auxConf.getJvmMaxMemoryMB().isPresent()) {
+        throw new MyriadBadConfigurationException("memory is not defined for task with name: " + taskName);        
+      }
+      return auxConf.getJvmMaxMemoryMB().get();
+
+    }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -15,9 +15,10 @@
  */
 package com.ebay.myriad.scheduler.event.handlers;
 
-import com.ebay.myriad.scheduler.NMPorts;
-import com.ebay.myriad.scheduler.NMProfile;
 import com.ebay.myriad.scheduler.SchedulerUtils;
+import com.ebay.myriad.scheduler.ServiceResourceProfile;
+import com.ebay.myriad.scheduler.TaskConstraints;
+import com.ebay.myriad.scheduler.TaskConstraintsManager;
 import com.ebay.myriad.scheduler.TaskFactory;
 import com.ebay.myriad.scheduler.TaskUtils;
 import com.ebay.myriad.scheduler.constraints.Constraint;
@@ -29,6 +30,7 @@ import com.ebay.myriad.state.SchedulerState;
 import com.lmax.disruptor.EventHandler;
 
 import java.util.Iterator;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
@@ -62,13 +64,16 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
   private SchedulerState schedulerState;
 
   @Inject
-  private TaskFactory taskFactory;
-
-  @Inject
   private TaskUtils taskUtils;
 
   @Inject
+  private Map<String, TaskFactory> taskFactoryMap;
+
+  @Inject
   private OfferLifecycleManager offerLifecycleMgr;
+  
+  @Inject
+  private TaskConstraintsManager taskConstraintsManager;
 
   @Override
   public void onEvent(ResourceOffersEvent event, long sequence,
@@ -92,8 +97,8 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     try {
       for (Iterator<Offer> iterator = offers.iterator(); iterator.hasNext();) {
         Offer offer = iterator.next();
-        NodeTask nodeTask = schedulerState.getNodeTask(offer.getSlaveId());
-        if (nodeTask != null) {
+        Set<NodeTask> nodeTasks = schedulerState.getNodeTasks(offer.getSlaveId());
+        for (NodeTask nodeTask : nodeTasks) {
           nodeTask.setSlaveAttributes(offer.getAttributesList());
         }
         Set<Protos.TaskID> pendingTasks = schedulerState.getPendingTaskIds();
@@ -101,34 +106,39 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
           for (Protos.TaskID pendingTaskId : pendingTasks) {
             NodeTask taskToLaunch = schedulerState
                 .getTask(pendingTaskId);
-            NMProfile profile = taskToLaunch.getProfile();
+            String taskPrefix = taskToLaunch.getTaskPrefix();
+            ServiceResourceProfile profile = taskToLaunch.getProfile();
             Constraint constraint = taskToLaunch.getConstraint();
 
-            if (matches(offer, profile, constraint)
-                && SchedulerUtils.isUniqueHostname(offer,
+            if (matches(offer, taskToLaunch, constraint)
+                && SchedulerUtils.isUniqueHostname(offer, taskToLaunch,
                 schedulerState.getActiveTasks())) {
-              TaskInfo task = taskFactory.createTask(offer, schedulerState.getFrameworkID(), pendingTaskId,
-                  taskToLaunch);
-
-              List<OfferID> offerIds = new ArrayList<>();
-              offerIds.add(offer.getId());
-              List<TaskInfo> tasks = new ArrayList<>();
-              tasks.add(task);
-              LOGGER.info("Launching task: {} using offer: {}", task.getTaskId().getValue(), offer.getId());
-              LOGGER.debug("Launching task: {} with profile: {} using offer: {}", task, profile, offer);
-              driver.launchTasks(offerIds, tasks);
-              schedulerState.makeTaskStaging(pendingTaskId);
-
-              // For every NM Task that we launch, we currently
-              // need to backup the ExecutorInfo for that NM Task in the State Store.
-              // Without this, we will not be able to launch tasks corresponding to yarn
-              // containers. This is specially important in case the RM restarts.
-              taskToLaunch.setExecutorInfo(task.getExecutor());
-              taskToLaunch.setHostname(offer.getHostname());
-              taskToLaunch.setSlaveId(offer.getSlaveId());
-              schedulerState.addTask(pendingTaskId, taskToLaunch);
-              iterator.remove(); // remove the used offer from offers list
-              break;
+              try {
+                final TaskInfo task = 
+                      taskFactoryMap.get(taskPrefix).createTask(offer, schedulerState.getFrameworkID(), pendingTaskId,
+                      taskToLaunch);
+                List<OfferID> offerIds = new ArrayList<>();
+                offerIds.add(offer.getId());
+                List<TaskInfo> tasks = new ArrayList<>();
+                tasks.add(task);
+                LOGGER.info("Launching task: {} using offer: {}", task.getTaskId().getValue(), offer.getId());
+                LOGGER.debug("Launching task: {} with profile: {} using offer: {}", task, profile, offer);
+                driver.launchTasks(offerIds, tasks);
+                schedulerState.makeTaskStaging(pendingTaskId);
+  
+                // For every NM Task that we launch, we currently
+                // need to backup the ExecutorInfo for that NM Task in the State Store.
+                // Without this, we will not be able to launch tasks corresponding to yarn
+                // containers. This is specially important in case the RM restarts.
+                taskToLaunch.setExecutorInfo(task.getExecutor());
+                taskToLaunch.setHostname(offer.getHostname());
+                taskToLaunch.setSlaveId(offer.getSlaveId());
+                schedulerState.addTask(pendingTaskId, taskToLaunch);
+                iterator.remove(); // remove the used offer from offers list
+                break;
+              } catch (Throwable t) {
+                LOGGER.error("Exception thrown while trying to create a task for {}", taskPrefix, t);
+              }
             }
           }
         }
@@ -153,12 +163,10 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     }
   }
 
-  private boolean matches(Offer offer, NMProfile profile, Constraint constraint) {
-
+  private boolean matches(Offer offer, NodeTask taskToLaunch, Constraint constraint) {
     if (!meetsConstraint(offer, constraint)) {
       return false;
     }
-
     Map<String, Object> results = new HashMap<String, Object>(5);
 
     for (Resource resource : offer.getResourcesList()) {
@@ -177,8 +185,25 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     checkResource(mem < 0, "mem");
     checkResource(ports < 0, "port");
 
-    return checkAggregates(profile, ports, cpus, mem);
+    return checkAggregates(offer, taskToLaunch, ports, cpus, mem);
   }
+
+    private boolean checkAggregates(Offer offer, NodeTask taskToLaunch, int ports, double cpus, double mem) {
+        final ServiceResourceProfile profile = taskToLaunch.getProfile();
+        final String taskPrefix = taskToLaunch.getTaskPrefix();
+        final double aggrCpu = profile.getAggregateCpu() + profile.getExecutorCpu();
+        final double aggrMem = profile.getAggregateMemory() + profile.getExecutorMemory();
+        final TaskConstraints taskConstraints = taskConstraintsManager.getConstraints(taskPrefix);
+        if (aggrCpu <= cpus
+            && aggrMem <= mem
+            && taskConstraints.portsCount() <= ports) {
+            return true;
+        } else {
+            LOGGER.info("Offer not sufficient for task with, cpu: {}, memory: {}, ports: {}",
+                aggrCpu, aggrMem, ports);
+            return false;
+        }
+    }
 
   private boolean meetsConstraint(Offer offer, Constraint constraint) {
     if (constraint != null) {
@@ -192,6 +217,8 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
             return likeConstraint.matchesSlaveAttributes(offer.getAttributesList());
           }
         }
+      default:
+        return false;
       }
     }
     return true;
@@ -200,20 +227,6 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
   private void checkResource(boolean fail, String resource) {
     if (fail) {
       LOGGER.info("No " + resource + " resources present");
-    }
-  }
-
-  private boolean checkAggregates(NMProfile profile, int ports, double cpus, double mem) {
-
-    if (taskUtils.getAggregateCpus(profile) <= cpus
-        && taskUtils.getAggregateMemory(profile) <= mem
-        && NMPorts.expectedNumPorts() <= ports) {
-      return true;
-    } else {
-      LOGGER.info("Offer not sufficient for launching task. Task requires cpu: {}, memory: {}, # of ports: {}. " +
-          "Offer has cpu: {}, memory: {}, # of ports: {}", taskUtils.getAggregateCpus(profile),
-          taskUtils.getAggregateMemory(profile), NMPorts.expectedNumPorts(), cpus, mem, ports);
-      return false;
     }
   }
 

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/fgs/YarnNodeCapacityManager.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/fgs/YarnNodeCapacityManager.java
@@ -1,7 +1,9 @@
 package com.ebay.myriad.scheduler.fgs;
 
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
 import com.ebay.myriad.executor.ContainerTaskStatusRequest;
 import com.ebay.myriad.scheduler.MyriadDriver;
+import com.ebay.myriad.scheduler.NMTaskFactoryAnnotation;
 import com.ebay.myriad.scheduler.SchedulerUtils;
 import com.ebay.myriad.scheduler.TaskFactory;
 import com.ebay.myriad.scheduler.yarn.interceptor.BaseInterceptor;
@@ -9,11 +11,13 @@ import com.ebay.myriad.scheduler.yarn.interceptor.InterceptorRegistry;
 import com.ebay.myriad.state.SchedulerState;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
+
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Resource;
@@ -60,7 +64,7 @@ public class YarnNodeCapacityManager extends BaseInterceptor {
                                    AbstractYarnScheduler yarnScheduler,
                                    RMContext rmContext,
                                    MyriadDriver myriadDriver,
-                                   TaskFactory taskFactory,
+                                   @NMTaskFactoryAnnotation TaskFactory taskFactory,
                                    OfferLifecycleManager offerLifecycleMgr,
                                    NodeStore nodeStore,
                                    SchedulerState state) {
@@ -215,7 +219,7 @@ public class YarnNodeCapacityManager extends BaseInterceptor {
         Protos.ExecutorInfo executorInfo = node.getExecInfo();
         if (executorInfo == null) {
             executorInfo = Protos.ExecutorInfo.newBuilder(
-                 state.getNodeTask(offer.getSlaveId()).getExecutorInfo())
+                 state.getNodeTask(offer.getSlaveId(), NodeManagerConfiguration.NM_TASK_PREFIX).getExecutorInfo())
                 .setFrameworkId(offer.getFrameworkId()).build();
             node.setExecInfo(executorInfo);
         }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/NodeTask.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/NodeTask.java
@@ -15,10 +15,13 @@
  */
 package com.ebay.myriad.state;
 
-import com.ebay.myriad.scheduler.NMProfile;
 import com.ebay.myriad.scheduler.constraints.Constraint;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import com.ebay.myriad.scheduler.ServiceResourceProfile;
+import com.ebay.myriad.scheduler.TaskUtils;
+import com.google.inject.Inject;
+
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Attribute;
 
@@ -27,14 +30,18 @@ import org.apache.mesos.Protos.Attribute;
  */
 public class NodeTask {
     @JsonProperty
-    private NMProfile profile;
-    @JsonProperty
     private String hostname;
     @JsonProperty
     private Protos.SlaveID slaveId;
     @JsonProperty
     private Protos.TaskStatus taskStatus;
+    @JsonProperty
+    private String taskPrefix;
+    @JsonProperty
+    private ServiceResourceProfile serviceresourceProfile;
 
+    @Inject
+    TaskUtils taskUtils;
     /**
      * Mesos executor for this node.
      */
@@ -43,8 +50,8 @@ public class NodeTask {
     private Constraint constraint;
     private List<Attribute> slaveAttributes;
 
-    public NodeTask(NMProfile profile, Constraint constraint) {
-        this.profile = profile;
+    public NodeTask(ServiceResourceProfile profile, Constraint constraint) {
+        this.serviceresourceProfile = profile;
         this.hostname = "";
         this.constraint = constraint;
     }
@@ -55,14 +62,6 @@ public class NodeTask {
 
     public void setSlaveId(Protos.SlaveID slaveId) {
         this.slaveId = slaveId;
-    }
-
-    public NMProfile getProfile() {
-        return profile;
-    }
-
-    public void setProfile(NMProfile profile) {
-        this.profile = profile;
     }
 
     public Constraint getConstraint() {
@@ -99,5 +98,21 @@ public class NodeTask {
 
     public List<Attribute> getSlaveAttributes() {
       return slaveAttributes;
+    }
+
+    public String getTaskPrefix() {
+      return taskPrefix;
+    }
+
+    public void setTaskPrefix(String taskPrefix) {
+      this.taskPrefix = taskPrefix;
+    }
+
+    public ServiceResourceProfile getProfile() {
+      return serviceresourceProfile;
+    }
+
+    public void setProfile(ServiceResourceProfile serviceresourceProfile) {
+      this.serviceresourceProfile = serviceresourceProfile;
     }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/SchedulerState.java
@@ -15,16 +15,27 @@
  */
 package com.ebay.myriad.state;
 
-import com.ebay.myriad.scheduler.NMProfile;
+import com.ebay.myriad.scheduler.ServiceResourceProfile;
 import com.ebay.myriad.state.utils.StoreContext;
+import com.google.common.collect.Sets;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.SlaveID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Represents the state of the Myriad scheduler
@@ -32,23 +43,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SchedulerState {
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerState.class);
 
+    private static Pattern taskIdPattern = Pattern.compile("\\.");
+    
     private Map<Protos.TaskID, NodeTask> tasks;
-    private Set<Protos.TaskID> pendingTasks;
-    private Set<Protos.TaskID> stagingTasks;
-    private Set<Protos.TaskID> activeTasks;
-    private Set<Protos.TaskID> lostTasks;
-    private Set<Protos.TaskID> killableTasks;
     private Protos.FrameworkID frameworkId;
     private MyriadStateStore stateStore;
+    private Map<String, SchedulerStateForType> statesForTaskType;
 
     public SchedulerState(MyriadStateStore stateStore) {
         this.tasks = new ConcurrentHashMap<>();
-        this.pendingTasks = new HashSet<>();
-        this.stagingTasks = new HashSet<>();
-        this.activeTasks = new HashSet<>();
-        this.lostTasks = new HashSet<>();
-        this.killableTasks = new HashSet<>();
         this.stateStore = stateStore;
+        this.statesForTaskType = new ConcurrentHashMap<>();
         loadStateStore();
     }
 
@@ -58,10 +63,12 @@ public class SchedulerState {
             return;
         }
         for (NodeTask node : nodes) {
-            Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue(String.format("nm.%s.%s", node.getProfile().getName(), UUID.randomUUID()))
+            Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue(String.format("%s.%s.%s", node.getTaskPrefix(), node.getProfile().getName(), UUID.randomUUID()))
                     .build();
             addTask(taskId, node);
-            LOGGER.info("Marked taskId {} pending, size of pending queue {}", taskId.getValue(), this.pendingTasks.size());
+            SchedulerStateForType taskState = this.statesForTaskType.get(node.getTaskPrefix());
+            LOGGER.info("Marked taskId {} pending, size of pending queue for {} is: {}", taskId.getValue(), node.getTaskPrefix(), 
+                (taskState == null ? 0 : taskState.getPendingTaskIds().size()));
             makeTaskPending(taskId);
         }
 
@@ -85,64 +92,66 @@ public class SchedulerState {
     public synchronized void makeTaskPending(Protos.TaskID taskId) {
         Objects.requireNonNull(taskId,
                 "taskId cannot be empty or null");
-        pendingTasks.add(taskId);
-        stagingTasks.remove(taskId);
-        activeTasks.remove(taskId);
-        lostTasks.remove(taskId);
-        killableTasks.remove(taskId);
+        String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+        SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+        if (taskTypeState == null) {
+          taskTypeState = new SchedulerStateForType(taskPrefix);
+          statesForTaskType.put(taskPrefix, taskTypeState);
+        }
+        taskTypeState.makeTaskPending(taskId);
         updateStateStore();
     }
 
     public synchronized void makeTaskStaging(Protos.TaskID taskId) {
         Objects.requireNonNull(taskId,
                 "taskId cannot be empty or null");
-
-        pendingTasks.remove(taskId);
-        stagingTasks.add(taskId);
-        activeTasks.remove(taskId);
-        lostTasks.remove(taskId);
-        killableTasks.remove(taskId);
+        String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+        SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+        if (taskTypeState == null) {
+          taskTypeState = new SchedulerStateForType(taskPrefix);
+          statesForTaskType.put(taskPrefix, taskTypeState);
+        }
+        taskTypeState.makeTaskStaging(taskId);
         updateStateStore();
     }
 
     public synchronized void makeTaskActive(Protos.TaskID taskId) {
         Objects.requireNonNull(taskId,
                 "taskId cannot be empty or null");
-
-        pendingTasks.remove(taskId);
-        stagingTasks.remove(taskId);
-        activeTasks.add(taskId);
-        lostTasks.remove(taskId);
-        killableTasks.remove(taskId);
+        String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+        SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+        if (taskTypeState == null) {
+          taskTypeState = new SchedulerStateForType(taskPrefix);
+          statesForTaskType.put(taskPrefix, taskTypeState);
+        }
+        taskTypeState.makeTaskActive(taskId);
         updateStateStore();
     }
 
     public synchronized void makeTaskLost(Protos.TaskID taskId) {
         Objects.requireNonNull(taskId,
                 "taskId cannot be empty or null");
-
-        pendingTasks.remove(taskId);
-        stagingTasks.remove(taskId);
-        activeTasks.remove(taskId);
-        lostTasks.add(taskId);
-        killableTasks.remove(taskId);
+        String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+        SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+        if (taskTypeState == null) {
+          taskTypeState = new SchedulerStateForType(taskPrefix);
+          statesForTaskType.put(taskPrefix, taskTypeState);
+        }
+        taskTypeState.makeTaskLost(taskId);
         updateStateStore();
     }
 
     public synchronized void makeTaskKillable(Protos.TaskID taskId) {
         Objects.requireNonNull(taskId,
                 "taskId cannot be empty or null");
-
-        pendingTasks.remove(taskId);
-        stagingTasks.remove(taskId);
-        activeTasks.remove(taskId);
-        lostTasks.remove(taskId);
-        killableTasks.add(taskId);
+        String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+        SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+        if (taskTypeState == null) {
+          taskTypeState = new SchedulerStateForType(taskPrefix);
+          statesForTaskType.put(taskPrefix, taskTypeState);
+        }
+        taskTypeState.makeTaskKillable(taskId);
         updateStateStore();
-    }
-
-    public synchronized Set<Protos.TaskID> getKillableTasks() {
-        return Collections.unmodifiableSet(this.killableTasks);
     }
 
     // TODO (sdaingade) Clone NodeTask
@@ -150,55 +159,89 @@ public class SchedulerState {
         return this.tasks.get(taskId);
     }
 
+    public synchronized Set<Protos.TaskID> getKillableTasks() {
+      Set<Protos.TaskID> returnSet = new HashSet<>();
+      for (Map.Entry<String, SchedulerStateForType> entry : statesForTaskType.entrySet()) {
+        returnSet.addAll(entry.getValue().getKillableTasks());
+      }
+      return returnSet;
+    }
+
+    public synchronized Set<Protos.TaskID> getKillableTasks(String taskPrefix) {
+      SchedulerStateForType stateTask = statesForTaskType.get(taskPrefix);
+      return (stateTask == null ? new HashSet<Protos.TaskID>() : stateTask.getKillableTasks());
+    }
+    
     public synchronized void removeTask(Protos.TaskID taskId) {
-        this.pendingTasks.remove(taskId);
-        this.stagingTasks.remove(taskId);
-        this.activeTasks.remove(taskId);
-        this.lostTasks.remove(taskId);
-        this.killableTasks.remove(taskId);
-        this.tasks.remove(taskId);
-        updateStateStore();
+      String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+      SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+      if (taskTypeState != null) {
+        taskTypeState.removeTask(taskId);
+      }
+      this.tasks.remove(taskId);
+      updateStateStore();
     }
 
     public synchronized Set<Protos.TaskID> getPendingTaskIds() {
-        return Collections.unmodifiableSet(this.pendingTasks);
+      Set<Protos.TaskID> returnSet = new HashSet<>();
+      for (Map.Entry<String, SchedulerStateForType> entry : statesForTaskType.entrySet()) {
+        returnSet.addAll(entry.getValue().getPendingTaskIds());
+      }
+      return returnSet;
     }
 
-    public synchronized Collection<Protos.TaskID> getPendingTaskIDsForProfile(NMProfile profile) {
+    public synchronized Collection<Protos.TaskID> getPendingTaskIDsForProfile(ServiceResourceProfile serviceProfile) {
       List<Protos.TaskID> pendingTaskIds = new ArrayList<>();
+      Set<Protos.TaskID> pendingTasks = getPendingTaskIds();
       for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
         NodeTask nodeTask = entry.getValue();
-        if (pendingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+        if (pendingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(serviceProfile.getName())) {
           pendingTaskIds.add(entry.getKey());
         }
       }
       return Collections.unmodifiableCollection(pendingTaskIds);
     }
 
+    public synchronized Set<Protos.TaskID> getPendingTaskIds(String taskPrefix) {
+      SchedulerStateForType stateTask = statesForTaskType.get(taskPrefix);
+      return (stateTask == null ? new HashSet<Protos.TaskID>() : stateTask.getPendingTaskIds());  
+    }
+    
     public synchronized Set<Protos.TaskID> getActiveTaskIds() {
-        return Collections.unmodifiableSet(this.activeTasks);
+      Set<Protos.TaskID> returnSet = new HashSet<>();
+      for (Map.Entry<String, SchedulerStateForType> entry : statesForTaskType.entrySet()) {
+        returnSet.addAll(entry.getValue().getActiveTaskIds());
+      }
+      return returnSet;
+    }
+    
+    public synchronized Set<Protos.TaskID> getActiveTaskIds(String taskPrefix) {
+      SchedulerStateForType stateTask = statesForTaskType.get(taskPrefix);
+      return (stateTask == null ? new HashSet<Protos.TaskID>() : stateTask.getActiveTaskIds());
     }
 
     public synchronized Collection<NodeTask> getActiveTasks() {
-        List<NodeTask> activeNodeTasks = new ArrayList<>();
-        if (CollectionUtils.isNotEmpty(activeTasks)
-                && CollectionUtils.isNotEmpty(tasks.values())) {
-            for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
-                if (activeTasks.contains(entry.getKey())) {
-                    activeNodeTasks.add(entry.getValue());
-                }
-            }
+      List<NodeTask> activeNodeTasks = new ArrayList<>();
+      Set<Protos.TaskID> activeTaskIds = getActiveTaskIds();
+      if (activeTaskIds.isEmpty()) {
+        return activeNodeTasks;
+      }
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        if (activeTaskIds.contains(entry.getKey())) {
+          activeNodeTasks.add(entry.getValue());
         }
-        return Collections.unmodifiableCollection(activeNodeTasks);
+      }
+      return activeNodeTasks;
     }
 
-    public synchronized Collection<Protos.TaskID> getActiveTaskIDsForProfile(NMProfile profile) {
+    public synchronized Collection<Protos.TaskID> getActiveTaskIDsForProfile(ServiceResourceProfile serviceProfile) {
       List<Protos.TaskID> activeTaskIDs = new ArrayList<>();
-      if (CollectionUtils.isNotEmpty(activeTasks)
+      Set<Protos.TaskID> activeTaskIds = getActiveTaskIds();
+      if (CollectionUtils.isNotEmpty(activeTaskIds)
           && CollectionUtils.isNotEmpty(tasks.values())) {
         for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
           NodeTask nodeTask = entry.getValue();
-          if (activeTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+          if (activeTaskIds.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(serviceProfile.getName())) {
             activeTaskIDs.add(entry.getKey());
           }
         }
@@ -206,34 +249,86 @@ public class SchedulerState {
       return Collections.unmodifiableCollection(activeTaskIDs);
     }
 
-  // TODO (sdaingade) Clone NodeTask
-    public synchronized NodeTask getNodeTask(SlaveID slaveId) {
-        for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
-            if (entry.getValue().getSlaveId() != null &&
-                entry.getValue().getSlaveId().equals(slaveId)) {
-                return entry.getValue(); 
-            }
+    public Collection<NodeTask> getActiveTasksByType(String taskPrefix) {
+      List<NodeTask> activeNodeTasks = new ArrayList<>();
+      Set<Protos.TaskID> activeTaskIds = getActiveTaskIds(taskPrefix);
+      if (activeTaskIds.isEmpty()) {
+        return activeNodeTasks;
+      }
+
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        if (activeTaskIds.contains(entry.getKey())) {
+          activeNodeTasks.add(entry.getValue());
         }
+      }
+      return activeNodeTasks;
+   }
+
+   // TODO (sdaingade) Clone NodeTask
+    public synchronized NodeTask getNodeTask(SlaveID slaveId, String taskPrefix) {
+      if (taskPrefix == null) {
         return null;
+      }
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        final NodeTask task = entry.getValue();
+        if (task.getSlaveId() != null &&
+            task.getSlaveId().equals(slaveId) &&
+            taskPrefix.equals(task.getTaskPrefix())) {
+            return entry.getValue(); 
+        }
+      }
+      return null;
     }
 
-    public synchronized Set<Protos.TaskID> getStagingTaskIds() {
-        return Collections.unmodifiableSet(this.stagingTasks);
+    public synchronized Set<NodeTask> getNodeTasks(SlaveID slaveId) {
+      Set<NodeTask> nodeTasks = Sets.newHashSet();
+      for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
+        final NodeTask task = entry.getValue();
+        if (task.getSlaveId() != null &&
+            task.getSlaveId().equals(slaveId)) {
+          nodeTasks.add(entry.getValue()); 
+        }
+      }
+      return nodeTasks;
     }
 
-    public synchronized Collection<Protos.TaskID> getStagingTaskIDsForProfile(NMProfile profile) {
+    public Set<Protos.TaskID> getStagingTaskIds() {
+      Set<Protos.TaskID> returnSet = new HashSet<>();
+      for (Map.Entry<String, SchedulerStateForType> entry : statesForTaskType.entrySet()) {
+        returnSet.addAll(entry.getValue().getStagingTaskIds());
+      }
+      return returnSet;
+    }
+
+    public synchronized Collection<Protos.TaskID> getStagingTaskIDsForProfile(ServiceResourceProfile serviceProfile) {
       List<Protos.TaskID> stagingTaskIDs = new ArrayList<>();
+      
+      Set<Protos.TaskID> stagingTasks = getStagingTaskIds();
       for (Map.Entry<Protos.TaskID, NodeTask> entry : tasks.entrySet()) {
         NodeTask nodeTask = entry.getValue();
-        if (stagingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(profile.getName())) {
+        if (stagingTasks.contains(entry.getKey()) && nodeTask.getProfile().getName().equals(serviceProfile.getName())) {
           stagingTaskIDs.add(entry.getKey());
         }
       }
       return Collections.unmodifiableCollection(stagingTaskIDs);
     }
 
-  public synchronized Set<Protos.TaskID> getLostTaskIds() {
-        return Collections.unmodifiableSet(this.lostTasks);
+    public Set<Protos.TaskID> getStagingTaskIds(String taskPrefix) {
+      SchedulerStateForType stateTask = statesForTaskType.get(taskPrefix);
+      return (stateTask == null ? new HashSet<Protos.TaskID>() : stateTask.getStagingTaskIds());
+    }
+    
+    public Set<Protos.TaskID> getLostTaskIds() {
+      Set<Protos.TaskID> returnSet = new HashSet<>();
+      for (Map.Entry<String, SchedulerStateForType> entry : statesForTaskType.entrySet()) {
+        returnSet.addAll(entry.getValue().getLostTaskIds());
+      }
+      return returnSet;
+    }
+    
+    public Set<Protos.TaskID> getLostTaskIds(String taskPrefix) {
+      SchedulerStateForType stateTask = statesForTaskType.get(taskPrefix);
+      return (stateTask == null ? new HashSet<Protos.TaskID>() : stateTask.getLostTaskIds());
     }
 
     // TODO (sdaingade) Currently cannot return unmodifiableCollection
@@ -271,8 +366,8 @@ public class SchedulerState {
         }
 
         try {
-            StoreContext sc = new StoreContext(frameworkId, tasks, pendingTasks,
-                stagingTasks, activeTasks, lostTasks, killableTasks);
+            StoreContext sc = new StoreContext(frameworkId, tasks, getPendingTaskIds(),
+                getStagingTaskIds(), getActiveTaskIds(), getLostTaskIds(), getKillableTasks());
             stateStore.storeMyriadState(sc);
         } catch (Exception e) {
             LOGGER.error("Failed to update scheduler state to state store", e);
@@ -290,23 +385,168 @@ public class SchedulerState {
             if (sc != null) {
                 this.frameworkId = sc.getFrameworkId();
                 this.tasks.putAll(sc.getTasks());
-                this.pendingTasks.addAll(sc.getPendingTasks());
-                this.stagingTasks.addAll(sc.getStagingTasks());
-                this.activeTasks.addAll(sc.getActiveTasks());
-                this.lostTasks.addAll(sc.getLostTasks());
-                this.killableTasks.addAll(sc.getKillableTasks());
-
+                convertToThis(TaskState.PENDING, sc.getPendingTasks());
+                convertToThis(TaskState.STAGING, sc.getStagingTasks());
+                convertToThis(TaskState.ACTIVE, sc.getActiveTasks());
+                convertToThis(TaskState.LOST, sc.getLostTasks());
+                convertToThis(TaskState.KILLABLE, sc.getKillableTasks());
                 LOGGER.info("Loaded Myriad state from state store successfully.");
                 LOGGER.debug("State Store state includes " +
                   "frameworkId: {}, pending tasks count: {}, staging tasks count: {} " +
                   "active tasks count: {}, lost tasks count: {}, " +
                   "and killable tasks count: {}", frameworkId.getValue(),
-                  this.pendingTasks.size(), this.stagingTasks.size(),
-                  this.activeTasks.size(), this.lostTasks.size(),
-                  this.killableTasks.size());
+                  this.getPendingTaskIds().size(), this.getStagingTaskIds().size(),
+                  this.getActiveTaskIds().size(), this.getLostTaskIds().size(),
+                  this.getKillableTasks().size());
             }
         }  catch (Exception e) {
             LOGGER.error("Failed to read scheduler state from state store", e);
         }
+   }
+
+   private void convertToThis(TaskState taskType, Set<Protos.TaskID> taskIds) {
+     for (Protos.TaskID taskId : taskIds) {
+       String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+       SchedulerStateForType taskTypeState = statesForTaskType.get(taskPrefix);
+       if (taskTypeState == null) {
+         taskTypeState = new SchedulerStateForType(taskPrefix);
+         statesForTaskType.put(taskPrefix, taskTypeState);
+       }
+       switch(taskType) {
+       case PENDING:
+         taskTypeState.makeTaskPending(taskId);
+         break;
+       case STAGING:
+         taskTypeState.makeTaskStaging(taskId);
+         break;
+       case ACTIVE:
+         taskTypeState.makeTaskActive(taskId);
+         break;
+       case KILLABLE:
+         taskTypeState.makeTaskKillable(taskId);
+         break;
+       case LOST:
+         taskTypeState.makeTaskLost(taskId);
+         break;
+       }
+     }
+   }
+   /**
+    * Class to keep all the tasks states for a particular taskPrefix together
+    *
+    */
+   private static class SchedulerStateForType {
+      
+    private final String taskPrefix;
+    private Set<Protos.TaskID> pendingTasks;
+    private Set<Protos.TaskID> stagingTasks;
+    private Set<Protos.TaskID> activeTasks;
+    private Set<Protos.TaskID> lostTasks;
+    private Set<Protos.TaskID> killableTasks;
+
+    public SchedulerStateForType(String taskPrefix) {
+      this.taskPrefix = taskPrefix;
+      this.pendingTasks = new HashSet<>();
+      this.stagingTasks = new HashSet<>();
+      this.activeTasks = new HashSet<>();
+      this.lostTasks = new HashSet<>();
+      this.killableTasks = new HashSet<>();
+
+    }
+    @SuppressWarnings("unused")
+    public String getTaskPrefix() {
+      return taskPrefix;
+    }
+    
+    public synchronized void makeTaskPending(Protos.TaskID taskId) {
+      Objects.requireNonNull(taskId,
+              "taskId cannot be empty or null");
+      
+      pendingTasks.add(taskId);
+      stagingTasks.remove(taskId);
+      activeTasks.remove(taskId);
+      lostTasks.remove(taskId);
+      killableTasks.remove(taskId);
+    }
+
+    public synchronized void makeTaskStaging(Protos.TaskID taskId) {
+        Objects.requireNonNull(taskId,
+                "taskId cannot be empty or null");
+        pendingTasks.remove(taskId);
+        stagingTasks.add(taskId);
+        activeTasks.remove(taskId);
+        lostTasks.remove(taskId);
+        killableTasks.remove(taskId);
+    }
+
+    public synchronized void makeTaskActive(Protos.TaskID taskId) {
+      Objects.requireNonNull(taskId,
+              "taskId cannot be empty or null");
+      pendingTasks.remove(taskId);
+      stagingTasks.remove(taskId);
+      activeTasks.add(taskId);
+      lostTasks.remove(taskId);
+      killableTasks.remove(taskId);
+    }
+
+    public synchronized void makeTaskLost(Protos.TaskID taskId) {
+      Objects.requireNonNull(taskId,
+              "taskId cannot be empty or null");
+      pendingTasks.remove(taskId);
+      stagingTasks.remove(taskId);
+      activeTasks.remove(taskId);
+      lostTasks.add(taskId);
+      killableTasks.remove(taskId);
+    }
+
+    public synchronized void makeTaskKillable(Protos.TaskID taskId) {
+      Objects.requireNonNull(taskId,
+              "taskId cannot be empty or null");
+      pendingTasks.remove(taskId);
+      stagingTasks.remove(taskId);
+      activeTasks.remove(taskId);
+      lostTasks.remove(taskId);
+      killableTasks.add(taskId);
+    }
+    
+    public synchronized void removeTask(Protos.TaskID taskId) {
+      this.pendingTasks.remove(taskId);
+      this.stagingTasks.remove(taskId);
+      this.activeTasks.remove(taskId);
+      this.lostTasks.remove(taskId);
+      this.killableTasks.remove(taskId);
+    }
+    
+    public synchronized Set<Protos.TaskID> getPendingTaskIds() {
+      return Collections.unmodifiableSet(this.pendingTasks);
+    }
+
+    public Set<Protos.TaskID> getActiveTaskIds() {
+      return Collections.unmodifiableSet(this.activeTasks);
+    }
+
+    public synchronized Set<Protos.TaskID> getStagingTaskIds() {
+      return Collections.unmodifiableSet(this.stagingTasks);
+    }
+
+    public synchronized Set<Protos.TaskID> getLostTaskIds() {
+      return Collections.unmodifiableSet(this.lostTasks);
+    }
+
+    public synchronized Set<Protos.TaskID> getKillableTasks() {
+      return Collections.unmodifiableSet(this.killableTasks);
+    }
+
+  }
+   /**
+    * TaskState type
+    *
+    */
+   public enum TaskState {
+     PENDING,
+     STAGING,
+     ACTIVE,
+     KILLABLE,
+     LOST
    }
 }

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/state/utils/StoreContext.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/state/utils/StoreContext.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Pattern;
+
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskID;
 
@@ -39,6 +41,7 @@ import com.ebay.myriad.state.NodeTask;
 * alternative approach.
 */
 public final class StoreContext {
+  private static Pattern taskIdPattern = Pattern.compile("\\.");
   private ByteBuffer frameworkId;
   private List<ByteBuffer> taskIds;
   private List<ByteBuffer> taskNodes;
@@ -188,8 +191,13 @@ public final class StoreContext {
       map = new HashMap<Protos.TaskID, NodeTask>(taskIds.size());
       int idx = 0;
       for (ByteBuffer bb : taskIds) {
-        map.put(ByteBufferSupport.toTaskId(bb),
-          ByteBufferSupport.toNodeTask(taskNodes.get(idx++)));
+        final Protos.TaskID taskId = ByteBufferSupport.toTaskId(bb);
+        final NodeTask task = ByteBufferSupport.toNodeTask(taskNodes.get(idx++));
+        if (task.getTaskPrefix() == null && taskId != null) {
+          String taskPrefix = taskIdPattern.split(taskId.getValue())[0];
+          task.setTaskPrefix(taskPrefix);
+        }
+        map.put(taskId, task);
       }
     } else {
       map = new HashMap<Protos.TaskID, NodeTask>(0);

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/MultiBindingsTest.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/MultiBindingsTest.java
@@ -1,0 +1,73 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ebay.myriad.scheduler.TaskFactory;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * Test for Multibindings
+ *
+ */
+public class MultiBindingsTest {
+
+  private static Injector injector;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    MyriadTestModule myriadModule = new MyriadTestModule();
+    injector = Guice.createInjector(
+            myriadModule);
+
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Test
+  public void multiBindingsTest() {
+    
+    
+    MultiBindingsUsage myinstance = injector.getInstance(MultiBindingsUsage.class);
+    
+    Map<String, TaskFactory> taskMap = myinstance.getMap();
+    assertNotNull(taskMap);
+    assertEquals(3, taskMap.size());
+    
+    taskMap = myinstance.getMap();
+    for (Map.Entry<String, TaskFactory> entry : taskMap.entrySet()) {
+      String keyName = entry.getKey();
+      TaskFactory taskFactory = entry.getValue();
+      System.out.println(taskFactory);
+    }
+    
+    
+  }
+
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/MultiBindingsUsage.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/MultiBindingsUsage.java
@@ -1,0 +1,39 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import com.ebay.myriad.scheduler.TaskFactory;
+
+/**
+ * Helper class to test multibindings
+ *
+ */
+public class MultiBindingsUsage {
+
+  @Inject
+  private Map<String, TaskFactory> taskFactoryMap;
+
+  public Map<String, TaskFactory> getMap() {
+    return taskFactoryMap;
+  }
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/MyriadTestModule.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/MyriadTestModule.java
@@ -1,0 +1,109 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ebay.myriad.configuration.ServiceConfiguration;
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.configuration.MyriadExecutorConfiguration;
+import com.ebay.myriad.configuration.NodeManagerConfiguration;
+import com.ebay.myriad.scheduler.TaskFactory.NMTaskFactoryImpl;
+import com.ebay.myriad.scheduler.DownloadNMExecutorCLGenImpl;
+import com.ebay.myriad.scheduler.ExecutorCommandLineGenerator;
+import com.ebay.myriad.scheduler.NMExecutorCLGenImpl;
+import com.ebay.myriad.scheduler.ServiceTaskFactoryImpl;
+import com.ebay.myriad.scheduler.TaskFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
+
+/**
+ * AbstractModule extension for UnitTests
+ *
+ */
+public class MyriadTestModule extends AbstractModule {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MyriadTestModule.class);
+  
+  private MyriadConfiguration cfg;
+  
+  @SuppressWarnings("unchecked")
+  @Override
+  protected void configure() {
+    
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    try {
+      cfg = mapper.readValue(
+              Thread.currentThread().getContextClassLoader().getResource("myriad-config-test-default.yml"),
+              MyriadConfiguration.class);
+    } catch (IOException e1) {
+      LOGGER.error("IOException", e1);
+      return;
+    }
+
+    if (cfg == null) {
+      return;
+    }
+    
+    bind(MyriadConfiguration.class).toInstance(cfg);
+
+    MapBinder<String, TaskFactory> mapBinder
+    = MapBinder.newMapBinder(binder(), String.class, TaskFactory.class);
+    mapBinder.addBinding(NodeManagerConfiguration.NM_TASK_PREFIX).to(NMTaskFactoryImpl.class).in(Scopes.SINGLETON);
+    Map<String, ServiceConfiguration> auxServicesConfigs = cfg.getServiceConfigurations();
+    for (Map.Entry<String, ServiceConfiguration> entry : auxServicesConfigs.entrySet()) {
+      String taskFactoryClass = entry.getValue().getTaskFactoryImplName().orNull();
+      if (taskFactoryClass != null) {
+        try {
+          Class<? extends TaskFactory> implClass = (Class<? extends TaskFactory>) Class.forName(taskFactoryClass);
+          mapBinder.addBinding(entry.getKey()).to(implClass).in(Scopes.SINGLETON);
+        } catch (ClassNotFoundException e) {
+          e.printStackTrace();
+        }
+      } else {
+        mapBinder.addBinding(entry.getKey()).to(ServiceTaskFactoryImpl.class).in(Scopes.SINGLETON);
+      }
+    }
+  }
+
+  @Provides
+  @Singleton
+  ExecutorCommandLineGenerator providesCLIGenerator(MyriadConfiguration cfg) {
+      ExecutorCommandLineGenerator cliGenerator = null;
+      MyriadExecutorConfiguration myriadExecutorConfiguration =
+          cfg.getMyriadExecutorConfiguration();
+      if (myriadExecutorConfiguration.getNodeManagerUri().isPresent()) {
+          cliGenerator = new DownloadNMExecutorCLGenImpl(cfg,
+             myriadExecutorConfiguration.getNodeManagerUri().get());
+      } else {
+          cliGenerator = new NMExecutorCLGenImpl(cfg);
+      }
+      return cliGenerator;
+  }    
+
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/configuration/MyriadBadConfigurationExceptionTest.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/configuration/MyriadBadConfigurationExceptionTest.java
@@ -1,0 +1,49 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.configuration;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Class to test MyriadBadConfigurationException
+ *
+ */
+public class MyriadBadConfigurationExceptionTest {
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Test
+  public void myriadExceptionTest() {
+    final String testStr = "com.ebay.myriad.configuration.MyriadBadConfigurationException: Bad configuration exception";
+    MyriadBadConfigurationException exp = new MyriadBadConfigurationException("Bad configuration exception");
+    
+    assertEquals(testStr, exp.toString());
+  }
+
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/configuration/MyriadConfigurationTest.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/configuration/MyriadConfigurationTest.java
@@ -1,0 +1,69 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.configuration;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * AuxServices/tasks test
+ *
+ */
+public class MyriadConfigurationTest {
+
+  static MyriadConfiguration cfg;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    cfg = mapper.readValue(
+            Thread.currentThread().getContextClassLoader().getResource("myriad-config-test-default.yml"),
+            MyriadConfiguration.class);
+
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Test
+  public void additionalPropertiestest() throws Exception {
+    
+    Map<String, ServiceConfiguration> auxConfigs = cfg.getServiceConfigurations();
+    
+    assertNotNull(auxConfigs);
+    assertEquals(auxConfigs.size(), 2);
+    
+    for (Map.Entry<String, ServiceConfiguration> entry : auxConfigs.entrySet()) {
+      String taskName = entry.getKey();
+      ServiceConfiguration config = entry.getValue();
+      String outTaskname = config.getTaskName();
+      assertEquals(taskName, outTaskname);
+    }
+  }
+
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/SchedulerUtilsSpec.groovy
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/SchedulerUtilsSpec.groovy
@@ -16,16 +16,16 @@ class SchedulerUtilsSpec extends Specification {
         offer.getHostname() >> "hostname"
 
         expect:
-        returnValue == SchedulerUtils.isUniqueHostname(offer, tasks)
+        returnValue == SchedulerUtils.isUniqueHostname(offer, launchTask, tasks)
 
         where:
-        tasks                                              | returnValue
-        []                                                 | true
-        null                                               | true
-        createNodeTaskList("hostname")                     | false
-        createNodeTaskList("missinghost")                  | true
-        createNodeTaskList("missinghost1", "missinghost2") | true
-        createNodeTaskList("missinghost1", "hostname")     | false
+        tasks                                              | launchTask 					| returnValue
+        []                                                 | null							| true
+        null                                               | null							| true
+        createNodeTaskList("hostname")                     | createNodeTask("hostname") 	| false
+        createNodeTaskList("missinghost")                  | createNodeTask("hostname") 	| true
+        createNodeTaskList("missinghost1", "missinghost2") | createNodeTask("missinghost3")	| true
+        createNodeTaskList("missinghost1", "hostname")     | createNodeTask("hostname")		| false
 
     }
 
@@ -39,8 +39,9 @@ class SchedulerUtilsSpec extends Specification {
 
 
     NodeTask createNodeTask(String hostname) {
-        def node = new NodeTask(new NMProfile("", 1, 1), null)
+        def node = new NodeTask(new ExtendedResourceProfile(new NMProfile("", 1, 1), 1.0,1.0), null)
         node.hostname = hostname
+        node.taskPrefix = "nm"
         node
     }
 }

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TMSTaskFactoryImpl.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TMSTaskFactoryImpl.java
@@ -1,0 +1,75 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.ebay.myriad.scheduler;
+
+import javax.inject.Inject;
+
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.state.NodeTask;
+
+/**
+ * Test implementation of TaskFactory
+ *
+ */
+public class TMSTaskFactoryImpl implements TaskFactory {
+
+  private MyriadConfiguration cfg;
+  private TaskUtils taskUtils;
+
+  @Inject
+  public TMSTaskFactoryImpl(MyriadConfiguration cfg, TaskUtils taskUtils) {
+      this.setCfg(cfg);
+      this.setTaskUtils(taskUtils);
+  }
+
+  @Override
+  public TaskInfo createTask(Offer offer, FrameworkID frameworkId, 
+      TaskID taskId, NodeTask nodeTask) {
+    return null;
+  }
+
+  public MyriadConfiguration getCfg() {
+    return cfg;
+  }
+
+  public void setCfg(MyriadConfiguration cfg) {
+    this.cfg = cfg;
+  }
+
+  public TaskUtils getTaskUtils() {
+    return taskUtils;
+  }
+
+  public void setTaskUtils(TaskUtils taskUtils) {
+    this.taskUtils = taskUtils;
+  }
+
+  @Override
+  public ExecutorInfo getExecutorInfoForSlave(FrameworkID frameworkId,
+      Offer offer, CommandInfo commandInfo) {
+    return null;
+  }
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestServiceCommandLine.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestServiceCommandLine.java
@@ -1,0 +1,68 @@
+package com.ebay.myriad.scheduler;
+
+import static org.junit.Assert.*;
+
+import org.apache.mesos.Protos.CommandInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.ebay.myriad.scheduler.TaskFactory.NMTaskFactoryImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Class to test CommandLine generation
+ *
+ */
+public class TestServiceCommandLine {
+
+  static MyriadConfiguration cfg;
+  
+  static String toJHSCompare = "echo \"sudo tar -zxpf hadoop-2.5.0.tar.gz && sudo chown hduser . &&" +
+      " cp conf /usr/local/hadoop/etc/hadoop/yarn-site.xml; sudo -E -u hduser -H $YARN_HOME/bin/mapred historyserver\";" +
+      "sudo tar -zxpf hadoop-2.5.0.tar.gz && sudo chown hduser . && cp conf /usr/local/hadoop/etc/hadoop/yarn-site.xml; sudo -E -u hduser -H $YARN_HOME/bin/mapred historyserver";
+  
+  static String toCompare = "echo \"sudo tar -zxpf hadoop-2.5.0.tar.gz && sudo chown hduser . && cp conf /usr/local/hadoop/etc/hadoop/yarn-site.xml;";
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    cfg = mapper.readValue(
+            Thread.currentThread().getContextClassLoader().getResource("myriad-config-test-default.yml"),
+            MyriadConfiguration.class);
+
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Test
+  public void testJHSCommandLineGeneration() throws Exception {
+    ServiceTaskFactoryImpl jhs = new ServiceTaskFactoryImpl(cfg, null);
+    String executorCmd = "$YARN_HOME/bin/mapred historyserver";
+    ServiceResourceProfile profile = new ServiceResourceProfile("jobhistory", 10.0, 15.0);
+    
+    CommandInfo cInfo = jhs.createCommandInfo(profile, executorCmd);
+     
+    assertTrue(cInfo.getValue().startsWith(toCompare));
+  }
+
+  @Test
+  public void testNMCommandLineGeneration() throws Exception {
+    Long [] ports = new Long [] {1L, 2L, 3L, 4L};
+    NMPorts nmPorts = new NMPorts(ports);
+    
+    ServiceResourceProfile profile = new ExtendedResourceProfile(new NMProfile("nm", 10L, 15L), 3.0, 5.0);
+    
+    ExecutorCommandLineGenerator clGenerator = new DownloadNMExecutorCLGenImpl(cfg, "hdfs://namenode:port/dist/hadoop-2.5.0.tar.gz");
+    NMTaskFactoryImpl nms = new NMTaskFactoryImpl(cfg, null, clGenerator);
+    
+    CommandInfo cInfo = nms.getCommandInfo(profile, nmPorts);
+    
+    assertTrue(cInfo.getValue().startsWith(toCompare));
+
+  }
+}

--- a/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestTaskUtils.java
+++ b/myriad-scheduler/src/test/java/com/ebay/myriad/scheduler/TestTaskUtils.java
@@ -1,0 +1,103 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ebay.myriad.scheduler;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ebay.myriad.configuration.MyriadBadConfigurationException;
+import com.ebay.myriad.configuration.MyriadConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Tests for TaskUtils
+ *
+ */
+public class TestTaskUtils {
+
+  static MyriadConfiguration cfg;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    cfg = mapper.readValue(
+            Thread.currentThread().getContextClassLoader().getResource("myriad-config-test-default.yml"),
+            MyriadConfiguration.class);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Test
+  public void testGetResource() {
+    TaskUtils taskUtils = new TaskUtils(cfg);
+    
+    NMProfile fooProfile = new NMProfile("abc", 1L, 1000L);
+    try {
+      taskUtils.getAuxTaskCpus(fooProfile, "foo");
+      fail("Should not complete sucessfully for foo");
+    } catch (MyriadBadConfigurationException e) {
+      // success
+    }
+    
+    try {
+      double cpu = taskUtils.getAuxTaskCpus(fooProfile, "jobhistory");
+      assertTrue(cpu > 0.0);
+    } catch (MyriadBadConfigurationException e) {
+      fail("cpu should be defined for jobhistory");
+    }    
+  }
+  
+  @Test
+  public void testServiceResourceProfile() throws Exception {
+    // testing custom deserializer
+    
+    Gson gson = new GsonBuilder().registerTypeAdapter(ServiceResourceProfile.class, new ServiceResourceProfile.CustomDeserializer()).create();
+    
+
+    ServiceResourceProfile parentProfile = new ServiceResourceProfile("abc", 1.0, 100.0);
+
+    String parentStr = gson.toJson(parentProfile);
+    ServiceResourceProfile processedProfile = gson.fromJson(parentStr, ServiceResourceProfile.class);
+    
+    assertTrue(processedProfile.getClass().equals(ServiceResourceProfile.class));
+    assertTrue(processedProfile.toString().equalsIgnoreCase(parentStr));
+    
+    ServiceResourceProfile childProfile = new ExtendedResourceProfile(new NMProfile("bcd", 5L, 15L), 2.0, 7.0);
+    
+    String childStr = gson.toJson(childProfile);
+    ServiceResourceProfile processedChildProfile = gson.fromJson(childStr, ServiceResourceProfile.class);
+
+    assertTrue(processedChildProfile instanceof ExtendedResourceProfile);
+    assertTrue(processedChildProfile.toString().equalsIgnoreCase(childStr));
+  }
+
+  @Test
+  
+  public void testStackTrace() {
+    
+    new Throwable().printStackTrace();
+  }
+}

--- a/myriad-scheduler/src/test/resources/myriad-config-test-default.yml
+++ b/myriad-scheduler/src/test/resources/myriad-config-test-default.yml
@@ -43,9 +43,9 @@ services:
      jvmMaxMemoryMB: 1024
      cpus: 1
      ports:
-       myriad.mapreduce.jobhistory.admin.address: -1
-       myriad.mapreduce.jobhistory.address: -1
-       myriad.mapreduce.jobhistory.webapp.address: -1
+       myriad.mapreduce.jobhistory.admin.address: 0
+       myriad.mapreduce.jobhistory.address: 0
+       myriad.mapreduce.jobhistory.webapp.address: 0
      envSettings: -Dcluster.name.prefix=/mycluster
      taskName: jobhistory
    timelineserver:

--- a/myriad-scheduler/src/test/resources/myriad-config-test-default.yml
+++ b/myriad-scheduler/src/test/resources/myriad-config-test-default.yml
@@ -1,0 +1,55 @@
+mesosMaster: 10.0.2.15:5050
+checkpoint: false
+frameworkFailoverTimeout: 43200000
+frameworkName: MyriadTest
+frameworkRole: 
+frameworkUser: hduser     # User the Node Manager runs as, required if nodeManagerURI set, otherwise defaults to the user
+                          # running the resource manager.
+frameworkSuperUser: root  # To be depricated, currently permissions need set by a superuser due to Mesos-1790.  Must be
+                          # root or have passwordless sudo. Required if nodeManagerURI set, ignored otherwise.
+nativeLibrary: /usr/local/lib/libmesos.so
+zkServers: localhost:2181
+zkTimeout: 20000
+restApiPort: 8192
+profiles:
+  small:
+    cpu: 1
+    mem: 1100
+  medium:
+    cpu: 2
+    mem: 2048
+  large:
+    cpu: 4
+    mem: 4096
+rebalancer: false
+nodemanager:
+  jvmMaxMemoryMB: 1024
+  cpus: 0.2
+  cgroups: false
+executor:
+  jvmMaxMemoryMB: 256
+  path: file:///usr/local/libexec/mesos/myriad-executor-runnable-0.0.1.jar
+  #The following should be used for a remotely distributed URI, hdfs assumed but other URI types valid.
+  nodeManagerUri: hdfs://namenode:port/dist/hadoop-2.5.0.tar.gz
+  #path: hdfs://namenode:port/dist/myriad-executor-runnable-0.0.1.jar
+yarnEnvironment:
+  YARN_HOME: /usr/local/hadoop
+  #YARN_HOME: hadoop-2.5.0 #this should be relative if nodeManagerUri is set
+  #JAVA_HOME: /usr/lib/jvm/java-default #System dependent, but sometimes necessary
+mesosAuthenticationPrincipal:
+mesosAuthenticationSecretFilename:
+services:
+   jobhistory:
+     jvmMaxMemoryMB: 1024
+     cpus: 1
+     ports:
+       myriad.mapreduce.jobhistory.admin.address: -1
+       myriad.mapreduce.jobhistory.address: -1
+       myriad.mapreduce.jobhistory.webapp.address: -1
+     envSettings: -Dcluster.name.prefix=/mycluster
+     taskName: jobhistory
+   timelineserver:
+     jvmMaxMemoryMB: 1024
+     cpus: 1
+     envSettings: -Dcluster.name.prefix=/mycluster2
+     taskName: timelineserver	


### PR DESCRIPTION
…it under Myriad umbrella from MyriadScheduler using default Mesos slave executor

Myriad-Issue-60 review changes

Disable automatic service startup at MyriadStartup, as upon Myriad restart it may try to start multiple times. Recovery of those tasks will be done as part of Myriad HA.

Added binary distribution for JHS. It is using same properties from yml file as NM, since source code for both should be same

Updating licensing info to Apache 2.0 License for newly created files

SchedulerState refactoring, naming changes, introduce limit on number of instances
of a particular service instances that can run at the same time.

Changed behavior with ports. New behavior: if ports are specified in the configuration they will be used irrespective of anything. If ports are not specified in configuration they will be selected form list of ports from Mesos offer.
In both cases following properties will be set:
        "myriad.mapreduce.jobhistory.admin.address",
        "myriad.mapreduce.jobhistory.address",
        "myriad.mapreduce.jobhistory.webapp.address"

So they can be used in configuration files. E.g:
<property>
  <name>mapreduce.jobhistory.admin.address</name>
  <value>${myriad.mapreduce.jobhistory.admin.address}</value>
</property>
<property>
  <name>mapreduce.jobhistory.address</name>
  <value>${myriad.mapreduce.jobhistory.address}</value>
</property>
<property>
  <name>mapreduce.jobhistory.webapp.address</name>
  <value>${myriad.mapreduce.jobhistory.webapp.address}</value>
</property>

In case of random ports JHS web app address  has to be known by clients in order to successfully start/finish job.

Fixing issue with resources for NM reporting as 0 and allowing submit a task that requires more resources then mess offer

Refactoring to abstract out ServiceResourceProfile and ExtendedProfile that will have NMProfile included in addition to service resources information. It helps to still keep all the tasks in one place.

Renamed to more meaningful names - such as Service(s), Refactoring command line generation for reuse between NM and others, Created interfacePorts to abstract out ports, rather then tagging along NMPorts class to other services, added tests for CommandLineGeneration

Fixes to unit test

MYRIAD-121  Reworked Service configuration, commands, etc. to rely just on the configuration settings to start the service

Example of configuration for JHS would be:
services:
   jobhistory:
     jvmMaxMemoryMB: 64
     cpus: 0.5
     ports:
       myriad.mapreduce.jobhistory.admin.address: 10033
       myriad.mapreduce.jobhistory.address: 10020
       myriad.mapreduce.jobhistory.webapp.address: 19888
     envSettings: -Dcluster.name.prefix=/mycluster
     taskName: jobhistory
     serviceOptsName: HADOOP_JOB_HISTORYSERVER_OPTS
     command: $YARN_HOME/bin/mapred historyserver
     maxInstances: 1

Addressed review comments

Addressing review comments, Adding handling exception in ResourceOffersEventHandler while TaskInfo is created to make sure thread is not stopped because of some rogue tasks

Adding DEFAULT_PORT_NUMBER and setting it to 0
